### PR TITLE
Fix incorrect integration expression

### DIFF
--- a/Example/Solver/SupportMotionGSSSSA.supan
+++ b/Example/Solver/SupportMotionGSSSSA.supan
@@ -1,0 +1,37 @@
+# A TEST MODEL FOR SUPPORTMOTION INTEGRATOR
+
+node 1 0 0
+node 2 0 1
+
+material Elastic1D 1 100 .1
+
+section Rectangle2D 1 12 1 1
+
+element B21 1 1 2 1 6
+
+mass 2 2 10 1
+
+fix 1 2 1
+fix 2 3 1
+
+amplitude Tabular 1 EZ
+
+supportacceleration 2 1 .2 1 1
+
+hdf5recorder 1 Node U1 1 2
+
+step dynamic 1 25
+set ini_step_size 1E-2
+set fixed_step_size true
+
+integrator GSSSSU0 1 .6 .6 .6
+
+converger RelIncreDisp 1 1E-10 4 1
+
+analyze
+
+peek node 1 2
+
+save recorder 1
+
+exit

--- a/Example/Solver/SupportMotionGSSSSV.supan
+++ b/Example/Solver/SupportMotionGSSSSV.supan
@@ -1,0 +1,37 @@
+# A TEST MODEL FOR SUPPORTMOTION INTEGRATOR
+
+node 1 0 0
+node 2 0 1
+
+material Elastic1D 1 100 .1
+
+section Rectangle2D 1 12 1 1
+
+element B21 1 1 2 1 6
+
+mass 2 2 10 1
+
+fix 1 2 1
+fix 2 3 1
+
+amplitude Tabular 1 EZ
+
+supportvelocity 2 1 .2 1 1
+
+hdf5recorder 1 Node U1 1 2
+
+step dynamic 1 25
+set ini_step_size 1E-2
+set fixed_step_size true
+
+integrator GSSSSU0 1 .6 .6 .6
+
+converger RelIncreDisp 1 1E-10 4 1
+
+analyze
+
+peek node 1 2
+
+save recorder 1
+
+exit

--- a/Solver/Integrator/GSSSS.cpp
+++ b/Solver/Integrator/GSSSS.cpp
@@ -175,13 +175,13 @@ void GSSSS::update_compatibility() const {
 vec GSSSS::from_incre_velocity(const vec& incre_velocity, const uvec& encoding) {
     auto& W = get_domain().lock()->get_factory();
 
-    return W->get_current_displacement()(encoding) + L1 * DT * W->get_current_velocity()(encoding) + (L2 - L3 * L4 / L5) * DT * DT * W->get_current_acceleration()(encoding) + L3 / L5 * DT * incre_velocity;
+    return W->get_current_displacement()(encoding) + L1 * DT * W1 * W->get_current_velocity()(encoding) + (L2 - L3 * L4 / L5) * DT * DT * W1 * W->get_current_acceleration()(encoding) + L3 / L5 * DT * W1 * incre_velocity;
 }
 
 vec GSSSS::from_incre_acceleration(const vec& incre_acceleration, const uvec& encoding) {
     auto& W = get_domain().lock()->get_factory();
 
-    return W->get_current_displacement()(encoding) + L1 * DT * W->get_current_velocity()(encoding) + L2 * DT * DT * W->get_current_acceleration()(encoding) + L3 * DT * DT * incre_acceleration;
+    return W->get_current_displacement()(encoding) + L1 * DT * W1 * W->get_current_velocity()(encoding) + L2 * DT * DT * W1 * W->get_current_acceleration()(encoding) + L3 * DT * DT * W1 * incre_acceleration;
 }
 
 void GSSSS::print() { suanpan_info("A time integrator using the GSSSS algorithm.\n"); }


### PR DESCRIPTION
The integration expressions from velocity/acceleration to displacement are incorrect in GSSSS integrator. An additional `W1` should be added.