### PR TITLE
Improve numerical stability

### DIFF
--- a/Example/Material/DuncanSeligDualStage.supan
+++ b/Example/Material/DuncanSeligDualStage.supan
@@ -1,0 +1,55 @@
+# A TEST MODEL FOR DUNCAN-SELIG MATERIAL
+
+node 1 0 0
+node 2 0 1
+node 3 0 2
+node 4 1 0
+node 5 1 1
+node 6 1 2
+
+material DuncanSelig 1 14.7 6000 .6 4000 .2 .7 .1 .7 .5
+
+element CP4 1 1 4 5 2 1
+element CP4 2 2 5 6 3 1
+
+fix 1 1 1 2 3 4 5 6
+fix 2 2 1 4
+
+hdf5recorder 1 Node RF 3 6
+hdf5recorder 2 Node U 3 6
+
+step static 1 1
+set fixed_step_size 1
+set ini_step_size 1E-1
+set symm_mat 0
+set band_mat 0
+
+displacement 1 0 -2E-2 2 3 6
+
+converger RelIncreDisp 1 1E-10 20 1
+
+step static 2 1
+set fixed_step_size 1
+set ini_step_size 1E-1
+set symm_mat 0
+set band_mat 0
+
+displacement 2 0 3E-3 2 3 6
+
+step static 3 1
+set fixed_step_size 1
+set ini_step_size 1E-1
+set symm_mat 0
+set band_mat 0
+
+displacement 3 0 -1E-2 2 3 6
+
+analyze
+
+peek element 1
+
+# save recorder 1 2
+
+reset
+clear
+exit

--- a/Material/Material2D/DuncanSelig.cpp
+++ b/Material/Material2D/DuncanSelig.cpp
@@ -219,9 +219,9 @@ int DuncanSelig::local_update(const vec& ref_stress, const vec& ref_strain, cons
     while(true) {
         if(max_iteration == ++counter) {
             if(two_stage)
-                suanpan_debug("Local iteration cannot converge within {} iterations.\n", max_iteration);
-            else
                 suanpan_error("Local iteration cannot converge within {} iterations.\n", max_iteration);
+            else
+                suanpan_debug("Local iteration cannot converge within {} iterations.\n", max_iteration);
             return SUANPAN_FAIL;
         }
 

--- a/Material/Material2D/DuncanSelig.cpp
+++ b/Material/Material2D/DuncanSelig.cpp
@@ -295,7 +295,7 @@ int DuncanSelig::update_trial_status(const vec& t_strain) {
     const auto ref_stress = trial_stress;
     const vec ref_strain = (1. - multiplier) * incre_strain;
 
-    auto counter = 0u;
+    counter = 0u;
     while(true) {
         if(max_iteration == ++counter) {
             suanpan_error("Cannot converge within {} iterations.\n", max_iteration);

--- a/Material/Material2D/DuncanSelig.cpp
+++ b/Material/Material2D/DuncanSelig.cpp
@@ -89,12 +89,12 @@ std::tuple<double, double, rowvec3, rowvec3> DuncanSelig::compute_elastic_moduli
 std::tuple<double, double, rowvec3, rowvec3> DuncanSelig::compute_plastic_moduli() {
     // principal stresses
 
-    const auto center = -.5 * (trial_stress(0) + trial_stress(1));
-    const rowvec3 dcds{-.5, -.5, 0.};
-
-    auto radius = .5 * dev(trial_stress);
+    const auto radius = .5 * dev(trial_stress);
     rowvec3 drds(fill::zeros);
     if(radius > datum::eps) drds = der_dev(trial_stress) / radius * .25;
+
+    const auto center = -.5 * (trial_stress(0) + trial_stress(1));
+    const rowvec3 dcds{-.5, -.5, 0.};
 
     const auto s1 = center + radius, s3 = center - radius;
 

--- a/Material/Material2D/DuncanSelig.cpp
+++ b/Material/Material2D/DuncanSelig.cpp
@@ -52,7 +52,7 @@ std::tuple<double, double> DuncanSelig::compute_bulk(const double s3) const {
     return {bulk, dkds3};
 }
 
-std::tuple<double, double, rowvec3, rowvec3> DuncanSelig::compute_elastic_moduli() {
+DuncanSelig::ds_moduli DuncanSelig::compute_elastic_moduli() {
     // principal stresses
 
     const auto radius = .5 * dev(trial_stress);
@@ -86,7 +86,7 @@ std::tuple<double, double, rowvec3, rowvec3> DuncanSelig::compute_elastic_moduli
     return {elastic, bulk, deds, dkds};
 }
 
-std::tuple<double, double, rowvec3, rowvec3> DuncanSelig::compute_plastic_moduli() {
+DuncanSelig::ds_moduli DuncanSelig::compute_plastic_moduli() {
     // principal stresses
 
     const auto radius = .5 * dev(trial_stress);
@@ -147,8 +147,8 @@ std::tuple<double, double, rowvec3, rowvec3> DuncanSelig::compute_plastic_moduli
     return {elastic, bulk, deds, dkds};
 }
 
-int DuncanSelig::project(double& multiplier) {
-    const auto& max_dev_stress = trial_history(0);
+int DuncanSelig::project_onto_surface(double& multiplier) {
+    const auto max_dev_stress = trial_history(0);
 
     trial_stress = current_stress + current_stiffness * incre_strain;
     multiplier = 1.;
@@ -161,7 +161,7 @@ int DuncanSelig::project(double& multiplier) {
     auto counter = 0u;
     while(true) {
         if(max_iteration == ++counter) {
-            suanpan_error("Cannot converge within {} iterations.\n", max_iteration);
+            suanpan_error("Local elastic iteration cannot converge within {} iterations.\n", max_iteration);
             return SUANPAN_FAIL;
         }
 
@@ -176,9 +176,10 @@ int DuncanSelig::project(double& multiplier) {
         right(2, 2) = 3. * bulk * elastic;
 
         const auto trial_dev_stress = dev(trial_stress);
-        const vec e_strain = incre_strain * multiplier;
+        const vec3 t_stress = trial_stress - current_stress;
+        const vec3 t_strain = incre_strain * multiplier;
 
-        residual.head(3) = (9. * bulk - elastic) * (trial_stress - current_stress) - right * e_strain;
+        residual.head(3) = (9. * bulk - elastic) * t_stress - right * t_strain;
         residual(3) = trial_dev_stress - max_dev_stress;
 
         const rowvec3 factor_c = 3. * (elastic * dkds + bulk * deds);
@@ -186,22 +187,78 @@ int DuncanSelig::project(double& multiplier) {
         const rowvec3 dfbds = 18. * bulk * dkds - factor_c;
 
         mat44 jacobian(fill::zeros);
-        jacobian(sa, sa) = (9. * bulk - elastic) * eye(3, 3) + (trial_stress - current_stress) * (9. * dkds - deds);
-        jacobian.row(0).head(3) -= e_strain(0) * dfads + e_strain(1) * dfbds;
-        jacobian.row(1).head(3) -= e_strain(0) * dfbds + e_strain(1) * dfads;
-        jacobian.row(2).head(3) -= e_strain(2) * factor_c;
+        jacobian(sa, sa) = (9. * bulk - elastic) * eye(3, 3) + t_stress * (9. * dkds - deds);
+        jacobian.row(0).head(3) -= t_strain(0) * dfads + t_strain(1) * dfbds;
+        jacobian.row(1).head(3) -= t_strain(0) * dfbds + t_strain(1) * dfads;
+        jacobian.row(2).head(3) -= t_strain(2) * factor_c;
         jacobian(sa, sb) = -right * incre_strain;
-        jacobian(sb, sa) = der_dev(trial_stress) / trial_dev_stress;
+        if(trial_dev_stress > datum::eps) jacobian(sb, sa) = der_dev(trial_stress) / trial_dev_stress;
+
+        if(!solve(incre, jacobian, residual)) return SUANPAN_FAIL;
+
+        const auto error = inf_norm(incre);
+        if(1u == counter) ref_error = error;
+        suanpan_debug("Local elastic iteration error: {:.5E}.\n", error / ref_error);
+        if(error < tolerance * ref_error || ((error < tolerance || inf_norm(residual) < tolerance) && counter > 5u)) return SUANPAN_SUCCESS;
+
+        trial_stress -= incre.head(3);
+        multiplier -= incre(3);
+    }
+}
+
+int DuncanSelig::local_update(const vec& ref_stress, const vec& ref_strain, const bool two_stage) {
+    const auto update_moduli = [&] {
+        const auto max_dev_stress = trial_history(0);
+        return two_stage || dev(trial_stress) > max_dev_stress ? compute_plastic_moduli() : compute_elastic_moduli();
+    };
+
+    auto ref_error = 0.;
+    vec3 incre;
+
+    auto counter = 0u;
+    while(true) {
+        if(max_iteration == ++counter) {
+            if(two_stage)
+                suanpan_debug("Local iteration cannot converge within {} iterations.\n", max_iteration);
+            else
+                suanpan_error("Local iteration cannot converge within {} iterations.\n", max_iteration);
+            return SUANPAN_FAIL;
+        }
+
+        const auto [elastic, bulk, deds, dkds] = update_moduli();
+
+        const auto factor_a = 3. * bulk * (3. * bulk + elastic);
+        const auto factor_b = 3. * bulk * (3. * bulk - elastic);
+
+        mat33 right(fill::zeros);
+        right(0, 0) = right(1, 1) = factor_a;
+        right(0, 1) = right(1, 0) = factor_b;
+        right(2, 2) = 3. * bulk * elastic;
+
+        const vec3 t_stress = trial_stress - ref_stress;
+        const vec3 residual = (9. * bulk - elastic) * t_stress - right * ref_strain;
+
+        const rowvec3 factor_c = 3. * (elastic * dkds + bulk * deds);
+        const rowvec3 dfads = 18. * bulk * dkds + factor_c;
+        const rowvec3 dfbds = 18. * bulk * dkds - factor_c;
+
+        mat33 jacobian = (9. * bulk - elastic) * eye(3, 3) + t_stress * (9. * dkds - deds);
+        jacobian.row(0) -= ref_strain(0) * dfads + ref_strain(1) * dfbds;
+        jacobian.row(1) -= ref_strain(0) * dfbds + ref_strain(1) * dfads;
+        jacobian.row(2) -= ref_strain(2) * factor_c;
 
         if(!solve(incre, jacobian, residual)) return SUANPAN_FAIL;
 
         const auto error = inf_norm(incre);
         if(1u == counter) ref_error = error;
         suanpan_debug("Local iteration error: {:.5E}.\n", error / ref_error);
-        if(error < tolerance * ref_error || ((error < tolerance || inf_norm(residual) < tolerance) && counter > 5u)) return SUANPAN_SUCCESS;
+        if(error < tolerance * ref_error || ((error < tolerance || inf_norm(residual) < tolerance) && counter > 5u)) {
+            if(!solve(trial_stiffness, jacobian, right)) return SUANPAN_FAIL;
 
-        trial_stress -= incre.head(3);
-        multiplier -= incre(3);
+            return SUANPAN_SUCCESS;
+        }
+
+        trial_stress -= incre;
     }
 }
 
@@ -235,109 +292,28 @@ int DuncanSelig::update_trial_status(const vec& t_strain) {
     if(norm(incre_strain) <= datum::eps) return SUANPAN_SUCCESS;
 
     trial_history = current_history;
-    auto& max_dev_stress = trial_history(0);
 
-    trial_stress = current_stress + (trial_stiffness = current_stiffness) * incre_strain;
+    trial_stress = current_stress + current_stiffness * incre_strain;
 
-    auto ref_error = 0.;
-    vec3 incre;
+    const auto update_dev_stress = [&] {
+        auto& max_dev_stress = trial_history(0);
+        if(const auto trail_dev_stress = dev(trial_stress); trail_dev_stress > max_dev_stress) max_dev_stress = trail_dev_stress;
+        return SUANPAN_SUCCESS;
+    };
 
-    auto counter = 0u;
-    while(true) {
-        if(max_iteration == ++counter) {
-            suanpan_error("Cannot converge within {} iterations.\n", max_iteration);
-            break;
-        }
+    // first try a whole step size local iteration
+    if(SUANPAN_SUCCESS == local_update(current_stress, incre_strain, false)) return update_dev_stress();
 
-        const auto trial_dev_stress = dev(trial_stress);
-
-        const auto branch = trial_dev_stress > max_dev_stress ? &DuncanSelig::compute_plastic_moduli : &DuncanSelig::compute_elastic_moduli;
-
-        const auto [elastic, bulk, deds, dkds] = (this->*branch)();
-
-        const auto factor_a = 3. * bulk * (3. * bulk + elastic);
-        const auto factor_b = 3. * bulk * (3. * bulk - elastic);
-
-        mat33 right(fill::zeros);
-        right(0, 0) = right(1, 1) = factor_a;
-        right(0, 1) = right(1, 0) = factor_b;
-        right(2, 2) = 3. * bulk * elastic;
-
-        const vec3 residual = (9. * bulk - elastic) * (trial_stress - current_stress) - right * incre_strain;
-
-        const rowvec3 factor_c = 3. * (elastic * dkds + bulk * deds);
-        const rowvec3 dfads = 18. * bulk * dkds + factor_c;
-        const rowvec3 dfbds = 18. * bulk * dkds - factor_c;
-
-        mat33 jacobian = (9. * bulk - elastic) * eye(3, 3) + (trial_stress - current_stress) * (9. * dkds - deds);
-        jacobian.row(0) -= incre_strain(0) * dfads + incre_strain(1) * dfbds;
-        jacobian.row(1) -= incre_strain(0) * dfbds + incre_strain(1) * dfads;
-        jacobian.row(2) -= incre_strain(2) * factor_c;
-
-        if(!solve(incre, jacobian, residual)) return SUANPAN_FAIL;
-
-        const auto error = inf_norm(incre);
-        if(1u == counter) ref_error = error;
-        suanpan_debug("Local iteration error: {:.5E}.\n", error / ref_error);
-        if(error < tolerance * ref_error || ((error < tolerance || inf_norm(residual) < tolerance) && counter > 5u)) {
-            if(!solve(trial_stiffness, jacobian, right)) return SUANPAN_FAIL;
-
-            if(trial_dev_stress > max_dev_stress) max_dev_stress = trial_dev_stress;
-
-            return SUANPAN_SUCCESS;
-        }
-
-        trial_stress -= incre;
-    }
-
+    // if that fails, mostly likely due to discontinuity of the gradient
+    // assume proportional loading, project the stress onto the yield surface using elastic moduli
     auto multiplier = 1.;
-    if(SUANPAN_SUCCESS != project(multiplier)) return SUANPAN_FAIL;
-    const auto ref_stress = trial_stress;
-    const vec ref_strain = (1. - multiplier) * incre_strain;
+    if(SUANPAN_SUCCESS != project_onto_surface(multiplier)) return SUANPAN_FAIL;
 
-    counter = 0u;
-    while(true) {
-        if(max_iteration == ++counter) {
-            suanpan_error("Cannot converge within {} iterations.\n", max_iteration);
-            return SUANPAN_FAIL;
-        }
+    // then using plastic moduli to compute the new plastic state
+    // !!! the tangent operator is not algorithmically consistent in this case
+    if(SUANPAN_SUCCESS != local_update(vec(trial_stress), (1. - multiplier) * incre_strain, true)) return SUANPAN_FAIL;
 
-        const auto [elastic, bulk, deds, dkds] = compute_plastic_moduli();
-
-        const auto factor_a = 3. * bulk * (3. * bulk + elastic);
-        const auto factor_b = 3. * bulk * (3. * bulk - elastic);
-
-        mat33 right(fill::zeros);
-        right(0, 0) = right(1, 1) = factor_a;
-        right(0, 1) = right(1, 0) = factor_b;
-        right(2, 2) = 3. * bulk * elastic;
-
-        const vec3 residual = (9. * bulk - elastic) * (trial_stress - ref_stress) - right * ref_strain;
-
-        const rowvec3 factor_c = 3. * (elastic * dkds + bulk * deds);
-        const rowvec3 dfads = 18. * bulk * dkds + factor_c;
-        const rowvec3 dfbds = 18. * bulk * dkds - factor_c;
-
-        mat33 jacobian = (9. * bulk - elastic) * eye(3, 3) + (trial_stress - ref_stress) * (9. * dkds - deds);
-        jacobian.row(0) -= ref_strain(0) * dfads + ref_strain(1) * dfbds;
-        jacobian.row(1) -= ref_strain(0) * dfbds + ref_strain(1) * dfads;
-        jacobian.row(2) -= ref_strain(2) * factor_c;
-
-        if(!solve(incre, jacobian, residual)) return SUANPAN_FAIL;
-
-        const auto error = inf_norm(incre);
-        if(1u == counter) ref_error = error;
-        suanpan_debug("Local iteration error: {:.5E}.\n", error / ref_error);
-        if(error < tolerance * ref_error || ((error < tolerance || inf_norm(residual) < tolerance) && counter > 5u)) {
-            if(!solve(trial_stiffness, jacobian, right)) return SUANPAN_FAIL;
-
-            max_dev_stress = dev(trial_stress);
-
-            return SUANPAN_SUCCESS;
-        }
-
-        trial_stress -= incre;
-    }
+    return update_dev_stress();
 }
 
 int DuncanSelig::clear_status() {

--- a/Material/Material2D/DuncanSelig.h
+++ b/Material/Material2D/DuncanSelig.h
@@ -51,6 +51,8 @@ class DuncanSelig final : public Material2D {
     [[nodiscard]] std::tuple<double, double, rowvec3, rowvec3> compute_elastic_moduli();
     [[nodiscard]] std::tuple<double, double, rowvec3, rowvec3> compute_plastic_moduli();
 
+    int project(double&);
+
 public:
     DuncanSelig(
         unsigned,   // tag

--- a/Material/Material2D/DuncanSelig.h
+++ b/Material/Material2D/DuncanSelig.h
@@ -41,6 +41,8 @@ class DuncanSelig final : public Material2D {
     static rowvec3 der_dev(const vec&);
     static mat compute_stiffness(double, double);
 
+    using ds_moduli = std::tuple<double, double, rowvec3, rowvec3>;
+
     double p_atm = 14.7;
     double ref_elastic = 400. * p_atm, n = .6;
     double ref_bulk = 300. * p_atm, m = .2;
@@ -48,10 +50,11 @@ class DuncanSelig final : public Material2D {
 
     [[nodiscard]] std::tuple<double, double> compute_elastic(double) const;
     [[nodiscard]] std::tuple<double, double> compute_bulk(double) const;
-    [[nodiscard]] std::tuple<double, double, rowvec3, rowvec3> compute_elastic_moduli();
-    [[nodiscard]] std::tuple<double, double, rowvec3, rowvec3> compute_plastic_moduli();
+    [[nodiscard]] ds_moduli compute_elastic_moduli();
+    [[nodiscard]] ds_moduli compute_plastic_moduli();
 
-    int project(double&);
+    int project_onto_surface(double&);
+    int local_update(const vec&, const vec&, bool);
 
 public:
     DuncanSelig(


### PR DESCRIPTION
Given the discontinuity of the tangent stiffness, the local Newton iteration may encounter failure when a single iteration body is utilized for both elastic and plastic computation.

In order to enhance numerical stability and robustness, it is proposed to divide the updating strategy into two distinct stages:

1. Initially, presume proportional loading and project the state onto the current yield surface.
2. Subsequently, execute a pure plastic update.