### PR TITLE
Update ExprTk to 0.0.3

### DIFF
--- a/Include/exprtk/exprtk.hpp
+++ b/Include/exprtk/exprtk.hpp
@@ -2393,6 +2393,8 @@ namespace exprtk
                case e_eof   : return ";";
                default      : return "UNKNOWN";
             }
+
+            return "UNKNOWN";
          }
 
          inline bool is_error() const


### PR DESCRIPTION
Release notes: https://www.partow.net/programming/exprtk/exprtk_release_notes_v0.0.3.txt

Note: This includes a revert of the previous update. 