### PR TITLE
Refactor and enhance allreduce functionality in matrix classes

### DIFF
--- a/Domain/Domain.cpp
+++ b/Domain/Domain.cpp
@@ -1128,8 +1128,6 @@ int Domain::process_load(const bool full) {
         }
     });
 
-    bcast_from_root(trial_load);
-
     factory->update_trial_load(trial_load);
     factory->update_trial_settlement(trial_settlement);
 
@@ -1267,10 +1265,6 @@ void Domain::update_constraint() {
 void Domain::assemble_load_stiffness() {}
 
 void Domain::assemble_constraint_stiffness() {
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     for(auto& I : get_constraint_pool())
         if(I->is_initialized() && !I->get_stiffness().empty()) factory->assemble_stiffness(I->get_stiffness(), I->get_dof_encoding());
 }

--- a/Domain/DomainState.cpp
+++ b/Domain/DomainState.cpp
@@ -25,13 +25,6 @@
 #include <Recorder/Recorder.h>
 
 void Domain::update_current_resistance() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_current_resistance()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
     factory->modify_trial_resistance().zeros();
     if(color_map.empty())
         for(const auto& I : element_pond.get()) factory->assemble_resistance(I->get_current_resistance(), I->get_dof_encoding());
@@ -47,13 +40,6 @@ void Domain::update_current_resistance() const {
 }
 
 void Domain::update_current_damping_force() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_current_damping_force()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
     factory->modify_trial_damping_force().zeros();
     if(color_map.empty())
         for(const auto& I : element_pond.get()) factory->assemble_damping_force(I->get_current_damping_force(), I->get_dof_encoding());
@@ -68,13 +54,6 @@ void Domain::update_current_damping_force() const {
 }
 
 void Domain::update_current_nonviscous_force() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_current_nonviscous_force()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
     factory->modify_trial_nonviscous_force().zeros();
     if(color_map.empty())
         for(const auto& I : element_pond.get()) factory->assemble_nonviscous_force(real(sum(I->get_current_nonviscous_force(), 1)), I->get_dof_encoding());
@@ -89,13 +68,6 @@ void Domain::update_current_nonviscous_force() const {
 }
 
 void Domain::update_current_inertial_force() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_current_inertial_force()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
     factory->modify_trial_inertial_force().zeros();
     if(color_map.empty())
         for(const auto& I : element_pond.get()) factory->assemble_inertial_force(I->get_current_inertial_force(), I->get_dof_encoding());
@@ -110,13 +82,6 @@ void Domain::update_current_inertial_force() const {
 }
 
 void Domain::assemble_resistance() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_trial_resistance()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
     auto& trial_resistance = factory->modify_trial_resistance().zeros();
     if(color_map.empty())
         for(const auto& I : element_pond.get()) factory->assemble_resistance(I->get_trial_resistance(), I->get_dof_encoding());
@@ -135,13 +100,6 @@ void Domain::assemble_resistance() const {
 }
 
 void Domain::assemble_damping_force() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_trial_damping_force()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
     auto& trial_damping_force = factory->modify_trial_damping_force().zeros();
     if(color_map.empty())
         for(const auto& I : element_pond.get()) factory->assemble_damping_force(I->get_trial_damping_force(), I->get_dof_encoding());
@@ -160,13 +118,6 @@ void Domain::assemble_damping_force() const {
 }
 
 void Domain::assemble_nonviscous_force() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_trial_nonviscous_force()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
     auto& trial_nonviscous_force = factory->modify_trial_nonviscous_force().zeros();
     if(color_map.empty())
         for(const auto& I : element_pond.get()) factory->assemble_nonviscous_force(real(sum(I->get_trial_nonviscous_force(), 1)), I->get_dof_encoding());
@@ -185,13 +136,6 @@ void Domain::assemble_nonviscous_force() const {
 }
 
 void Domain::assemble_inertial_force() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_trial_inertial_force()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
     auto& trial_inertial_force = factory->modify_trial_inertial_force().zeros();
     if(color_map.empty())
         for(const auto& I : element_pond.get()) factory->assemble_inertial_force(I->get_trial_inertial_force(), I->get_dof_encoding());
@@ -210,17 +154,6 @@ void Domain::assemble_inertial_force() const {
 }
 
 void Domain::assemble_initial_mass() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_initial_mass()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     factory->clear_mass();
     if(color_map.empty() || is_sparse())
         for(const auto& I : element_pond.get()) factory->assemble_mass(I->get_initial_mass(), I->get_dof_encoding(), I->get_dof_mapping());
@@ -236,17 +169,6 @@ void Domain::assemble_initial_mass() const {
 }
 
 void Domain::assemble_current_mass() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_current_mass()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     factory->clear_mass();
     if(color_map.empty() || is_sparse())
         for(const auto& I : element_pond.get()) factory->assemble_mass(I->get_current_mass(), I->get_dof_encoding(), I->get_dof_mapping());
@@ -262,17 +184,6 @@ void Domain::assemble_current_mass() const {
 }
 
 void Domain::assemble_trial_mass() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_trial_mass()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     factory->clear_mass();
     if(color_map.empty() || is_sparse())
         for(const auto& I : element_pond.get()) factory->assemble_mass(I->get_trial_mass(), I->get_dof_encoding(), I->get_dof_mapping());
@@ -288,17 +199,6 @@ void Domain::assemble_trial_mass() const {
 }
 
 void Domain::assemble_initial_damping() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_initial_viscous()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     factory->clear_damping();
     if(color_map.empty() || is_sparse())
         for(const auto& I : element_pond.get()) factory->assemble_damping(I->get_initial_viscous(), I->get_dof_encoding(), I->get_dof_mapping());
@@ -314,17 +214,6 @@ void Domain::assemble_initial_damping() const {
 }
 
 void Domain::assemble_current_damping() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_current_viscous()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     factory->clear_damping();
     if(color_map.empty() || is_sparse())
         for(const auto& I : element_pond.get()) factory->assemble_damping(I->get_current_viscous(), I->get_dof_encoding(), I->get_dof_mapping());
@@ -340,17 +229,6 @@ void Domain::assemble_current_damping() const {
 }
 
 void Domain::assemble_trial_damping() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_trial_viscous()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     factory->clear_damping();
     if(color_map.empty() || is_sparse())
         for(const auto& I : element_pond.get()) factory->assemble_damping(I->get_trial_viscous(), I->get_dof_encoding(), I->get_dof_mapping());
@@ -366,17 +244,6 @@ void Domain::assemble_trial_damping() const {
 }
 
 void Domain::assemble_initial_nonviscous() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_initial_nonviscous()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     if(!factory->is_nonviscous()) return;
     factory->clear_nonviscous();
     if(color_map.empty() || is_sparse())
@@ -393,17 +260,6 @@ void Domain::assemble_initial_nonviscous() const {
 }
 
 void Domain::assemble_current_nonviscous() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_current_nonviscous()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     if(!factory->is_nonviscous()) return;
     factory->clear_nonviscous();
     if(color_map.empty() || is_sparse())
@@ -420,17 +276,6 @@ void Domain::assemble_current_nonviscous() const {
 }
 
 void Domain::assemble_trial_nonviscous() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_trial_nonviscous()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     if(!factory->is_nonviscous()) return;
     factory->clear_nonviscous();
     if(color_map.empty() || is_sparse())
@@ -447,17 +292,6 @@ void Domain::assemble_trial_nonviscous() const {
 }
 
 void Domain::assemble_initial_stiffness() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_initial_stiffness()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     factory->clear_stiffness();
     if(color_map.empty() || is_sparse())
         for(const auto& I : element_pond.get()) factory->assemble_stiffness(I->get_initial_stiffness(), I->get_dof_encoding(), I->get_dof_mapping());
@@ -473,17 +307,6 @@ void Domain::assemble_initial_stiffness() const {
 }
 
 void Domain::assemble_current_stiffness() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_current_stiffness()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     factory->clear_stiffness();
     if(color_map.empty() || is_sparse())
         for(const auto& I : element_pond.get()) factory->assemble_stiffness(I->get_current_stiffness(), I->get_dof_encoding(), I->get_dof_mapping());
@@ -499,17 +322,6 @@ void Domain::assemble_current_stiffness() const {
 }
 
 void Domain::assemble_trial_stiffness() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_trial_stiffness()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     factory->clear_stiffness();
     if(color_map.empty() || is_sparse())
         for(const auto& I : element_pond.get()) factory->assemble_stiffness(I->get_trial_stiffness(), I->get_dof_encoding(), I->get_dof_mapping());
@@ -526,17 +338,6 @@ void Domain::assemble_trial_stiffness() const {
 
 void Domain::assemble_initial_geometry() const {
     if(!factory->is_nlgeom()) return;
-
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_initial_geometry()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
 
     factory->clear_geometry();
     if(color_map.empty() || is_sparse()) {
@@ -557,17 +358,6 @@ void Domain::assemble_initial_geometry() const {
 void Domain::assemble_current_geometry() const {
     if(!factory->is_nlgeom()) return;
 
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_current_geometry()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     factory->clear_geometry();
     if(color_map.empty() || is_sparse()) {
         for(const auto& I : element_pond.get())
@@ -587,17 +377,6 @@ void Domain::assemble_current_geometry() const {
 void Domain::assemble_trial_geometry() const {
     if(!factory->is_nlgeom()) return;
 
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_trial_geometry()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     factory->clear_geometry();
     if(color_map.empty() || is_sparse()) {
         for(const auto& I : element_pond.get())
@@ -615,17 +394,6 @@ void Domain::assemble_trial_geometry() const {
 }
 
 void Domain::assemble_mass_container() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_mass_container()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     factory->clear_mass();
     if(color_map.empty() || is_sparse())
         for(const auto& I : element_pond.get()) factory->assemble_mass(I->get_mass_container(), I->get_dof_encoding(), I->get_dof_mapping());
@@ -641,17 +409,6 @@ void Domain::assemble_mass_container() const {
 }
 
 void Domain::assemble_stiffness_container() const {
-#ifdef SUANPAN_DISTRIBUTED
-    mpl::irequest_pool requests;
-    for(auto& I : element_pond.get())
-        if(auto req = I->gather(I->get_stiffness_container()); req.has_value()) requests.push(std::move(req).value());
-    requests.waitall();
-#endif
-
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    // ReSharper disable once CppDFAUnreachableCode
-    if(0 != comm_rank) return;
-
     factory->clear_stiffness();
     if(color_map.empty() || is_sparse())
         for(const auto& I : element_pond.get()) factory->assemble_stiffness(I->get_stiffness_container(), I->get_dof_encoding(), I->get_dof_mapping());

--- a/Domain/DomainState.cpp
+++ b/Domain/DomainState.cpp
@@ -428,10 +428,6 @@ int Domain::update_trial_status() const {
     auto& trial_velocity = factory->get_trial_velocity();
     auto& trial_acceleration = factory->get_trial_acceleration();
 
-    bcast_from_root(trial_displacement);
-    bcast_from_root(trial_velocity);
-    bcast_from_root(trial_acceleration);
-
     if(AnalysisType::DYNAMICS == factory->get_analysis_type()) suanpan::for_all(node_pond.get(), [&](const shared_ptr<Node>& t_node) { t_node->update_trial_status(trial_displacement, trial_velocity, trial_acceleration); });
     else suanpan::for_all(node_pond.get(), [&](const shared_ptr<Node>& t_node) { t_node->update_trial_status(trial_displacement); });
 
@@ -447,10 +443,6 @@ int Domain::update_incre_status() const {
     auto& incre_displacement = factory->get_incre_displacement();
     auto& incre_velocity = factory->get_incre_velocity();
     auto& incre_acceleration = factory->get_incre_acceleration();
-
-    bcast_from_root(incre_displacement);
-    bcast_from_root(incre_velocity);
-    bcast_from_root(incre_acceleration);
 
     if(AnalysisType::DYNAMICS == factory->get_analysis_type()) suanpan::for_all(node_pond.get(), [&](const shared_ptr<Node>& t_node) { t_node->update_incre_status(incre_displacement, incre_velocity, incre_acceleration); });
     else suanpan::for_all(node_pond.get(), [&](const shared_ptr<Node>& t_node) { t_node->update_incre_status(incre_displacement); });

--- a/Domain/MetaMat/DenseMat.hpp
+++ b/Domain/MetaMat/DenseMat.hpp
@@ -125,6 +125,8 @@ public:
         for(unsigned I = 0; I < pivot.n_elem; ++I) if((this->operator()(I, I) < T(0)) ^ (static_cast<int>(I) + 1 != pivot(I))) det_sign = -det_sign;
         return det_sign;
     }
+
+    void allreduce() override { comm_world.allreduce(mpl::plus<T>(), memory.get(), mpl::contiguous_layout<T>{this->n_elem}); }
 };
 
 #endif

--- a/Domain/MetaMat/DenseMat.hpp
+++ b/Domain/MetaMat/DenseMat.hpp
@@ -126,7 +126,11 @@ public:
         return det_sign;
     }
 
-    void allreduce() override { comm_world.allreduce(mpl::plus<T>(), memory.get(), mpl::contiguous_layout<T>{this->n_elem}); }
+    void allreduce() override {
+#ifdef SUANPAN_DISTRIBUTED
+        comm_world.allreduce(mpl::plus<T>(), memory.get(), mpl::contiguous_layout<T>{this->n_elem});
+#endif
+    }
 };
 
 #endif

--- a/Domain/MetaMat/MetaMat.hpp
+++ b/Domain/MetaMat/MetaMat.hpp
@@ -209,6 +209,8 @@ public:
 
     [[nodiscard]] virtual int sign_det() const = 0;
 
+    virtual void allreduce() = 0;
+
     void save(const char* name) {
         if(!to_mat(*this).save(name, raw_ascii))
             suanpan_error("Cannot save to file \"{}\".\n", name);

--- a/Domain/MetaMat/SparseMat.hpp
+++ b/Domain/MetaMat/SparseMat.hpp
@@ -91,7 +91,11 @@ public:
 
     [[nodiscard]] int sign_det() const override { throw invalid_argument("not supported"); }
 
-    void allreduce() override { throw invalid_argument("not supported"); }
+    void allreduce() override {
+#ifdef SUANPAN_DISTRIBUTED
+        throw invalid_argument("not supported");
+#endif
+    }
 
     void csc_condense() override { this->triplet_mat.csc_condense(); }
 

--- a/Domain/MetaMat/SparseMat.hpp
+++ b/Domain/MetaMat/SparseMat.hpp
@@ -91,6 +91,8 @@ public:
 
     [[nodiscard]] int sign_det() const override { throw invalid_argument("not supported"); }
 
+    void allreduce() override { throw invalid_argument("not supported"); }
+
     void csc_condense() override { this->triplet_mat.csc_condense(); }
 
     void csr_condense() override { this->triplet_mat.csr_condense(); }

--- a/Solver/Integrator/Integrator.cpp
+++ b/Solver/Integrator/Integrator.cpp
@@ -263,69 +263,13 @@ mat Integrator::solve(sp_mat&& B) {
     return X;
 }
 
-int Integrator::solve(mat& X, const mat& B) {
-    int info{0};
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    if(0 == comm_rank) info = database.lock()->get_factory()->get_stiffness()->solve(X, B);
+int Integrator::solve(mat& X, const mat& B) { return database.lock()->get_factory()->get_stiffness()->solve(X, B); }
 
-    if(SUANPAN_SUCCESS == bcast_from_root(info)) {
-        // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-        // ReSharper disable once CppDFAUnreachableCode
-        if(0 != comm_rank) X.set_size(B.n_rows, B.n_cols);
-        bcast_from_root(X);
-    }
+int Integrator::solve(mat& X, const sp_mat& B) { return database.lock()->get_factory()->get_stiffness()->solve(X, B); }
 
-    return info;
-}
+int Integrator::solve(mat& X, mat&& B) { return database.lock()->get_factory()->get_stiffness()->solve(X, std::move(B)); }
 
-int Integrator::solve(mat& X, const sp_mat& B) {
-    int info{0};
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    if(0 == comm_rank) info = database.lock()->get_factory()->get_stiffness()->solve(X, B);
-
-    if(SUANPAN_SUCCESS == bcast_from_root(info)) {
-        // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-        // ReSharper disable once CppDFAUnreachableCode
-        if(0 != comm_rank) X.set_size(B.n_rows, B.n_cols);
-        bcast_from_root(X);
-    }
-
-    return info;
-}
-
-int Integrator::solve(mat& X, mat&& B) {
-    const auto n_rows = B.n_rows, n_cols = B.n_cols;
-
-    int info{0};
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    if(0 == comm_rank) info = database.lock()->get_factory()->get_stiffness()->solve(X, std::move(B));
-
-    if(SUANPAN_SUCCESS == bcast_from_root(info)) {
-        // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-        // ReSharper disable once CppDFAUnreachableCode
-        if(0 != comm_rank) X.set_size(n_rows, n_cols);
-        bcast_from_root(X);
-    }
-
-    return info;
-}
-
-int Integrator::solve(mat& X, sp_mat&& B) {
-    const auto n_rows = B.n_rows, n_cols = B.n_cols;
-
-    int info{0};
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    if(0 == comm_rank) info = database.lock()->get_factory()->get_stiffness()->solve(X, std::move(B));
-
-    if(SUANPAN_SUCCESS == bcast_from_root(info)) {
-        // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-        // ReSharper disable once CppDFAUnreachableCode
-        if(0 != comm_rank) X.set_size(n_rows, n_cols);
-        bcast_from_root(X);
-    }
-
-    return info;
-}
+int Integrator::solve(mat& X, sp_mat&& B) { return database.lock()->get_factory()->get_stiffness()->solve(X, std::move(B)); }
 
 /**
  * Avoid machine error accumulation.
@@ -422,69 +366,13 @@ void ExplicitIntegrator::update_from_ninja() {
     W->update_trial_acceleration_by(W->get_ninja());
 }
 
-int ExplicitIntegrator::solve(mat& X, const mat& B) {
-    int info{0};
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    if(0 == comm_rank) info = get_domain()->get_factory()->get_mass()->solve(X, B);
+int ExplicitIntegrator::solve(mat& X, const mat& B) { return get_domain()->get_factory()->get_mass()->solve(X, B); }
 
-    if(SUANPAN_SUCCESS == bcast_from_root(info)) {
-        // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-        // ReSharper disable once CppDFAUnreachableCode
-        if(0 != comm_rank) X.set_size(B.n_rows, B.n_cols);
-        bcast_from_root(X);
-    }
+int ExplicitIntegrator::solve(mat& X, const sp_mat& B) { return get_domain()->get_factory()->get_mass()->solve(X, B); }
 
-    return info;
-}
+int ExplicitIntegrator::solve(mat& X, mat&& B) { return get_domain()->get_factory()->get_mass()->solve(X, std::move(B)); }
 
-int ExplicitIntegrator::solve(mat& X, const sp_mat& B) {
-    int info{0};
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    if(0 == comm_rank) info = get_domain()->get_factory()->get_mass()->solve(X, B);
-
-    if(SUANPAN_SUCCESS == bcast_from_root(info)) {
-        // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-        // ReSharper disable once CppDFAUnreachableCode
-        if(0 != comm_rank) X.set_size(B.n_rows, B.n_cols);
-        bcast_from_root(X);
-    }
-
-    return info;
-}
-
-int ExplicitIntegrator::solve(mat& X, mat&& B) {
-    const auto n_rows = B.n_rows, n_cols = B.n_cols;
-
-    int info{0};
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    if(0 == comm_rank) info = get_domain()->get_factory()->get_mass()->solve(X, std::move(B));
-
-    if(SUANPAN_SUCCESS == bcast_from_root(info)) {
-        // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-        // ReSharper disable once CppDFAUnreachableCode
-        if(0 != comm_rank) X.set_size(n_rows, n_cols);
-        bcast_from_root(X);
-    }
-
-    return info;
-}
-
-int ExplicitIntegrator::solve(mat& X, sp_mat&& B) {
-    const auto n_rows = B.n_rows, n_cols = B.n_cols;
-
-    int info{0};
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    if(0 == comm_rank) info = get_domain()->get_factory()->get_mass()->solve(X, std::move(B));
-
-    if(SUANPAN_SUCCESS == bcast_from_root(info)) {
-        // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-        // ReSharper disable once CppDFAUnreachableCode
-        if(0 != comm_rank) X.set_size(n_rows, n_cols);
-        bcast_from_root(X);
-    }
-
-    return info;
-}
+int ExplicitIntegrator::solve(mat& X, sp_mat&& B) { return get_domain()->get_factory()->get_mass()->solve(X, std::move(B)); }
 
 vec ExplicitIntegrator::from_incre_velocity(const vec&, const uvec&) { throw invalid_argument("support velocity cannot be used with explicit integrator"); }
 

--- a/Solver/Integrator/LeeNewmarkBase.cpp
+++ b/Solver/Integrator/LeeNewmarkBase.cpp
@@ -92,36 +92,12 @@ int LeeNewmarkBase::update_internal(const mat& t_internal) {
 
 int LeeNewmarkBase::solve(mat& X, const mat& B) {
     stiffness->set_solver_setting(factory->get_solver_setting());
-
-    int info{0};
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    if(0 == comm_rank) info = stiffness->solve(X, resize(B, stiffness->n_rows, B.n_cols));
-
-    if(SUANPAN_SUCCESS == bcast_from_root(info)) {
-        // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-        // ReSharper disable once CppDFAUnreachableCode
-        if(0 != comm_rank) X.set_size(stiffness->n_rows, B.n_cols);
-        bcast_from_root(X);
-    }
-
-    return info;
+    return stiffness->solve(X, resize(B, stiffness->n_rows, B.n_cols));
 }
 
 int LeeNewmarkBase::solve(mat& X, const sp_mat& B) {
     stiffness->set_solver_setting(factory->get_solver_setting());
-
-    int info{0};
-    // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-    if(0 == comm_rank) info = stiffness->solve(X, resize(B, stiffness->n_rows, B.n_cols));
-
-    if(SUANPAN_SUCCESS == bcast_from_root(info)) {
-        // ReSharper disable once CppIfCanBeReplacedByConstexprIf
-        // ReSharper disable once CppDFAUnreachableCode
-        if(0 != comm_rank) X.set_size(stiffness->n_rows, B.n_cols);
-        bcast_from_root(X);
-    }
-
-    return info;
+    return stiffness->solve(X, resize(B, stiffness->n_rows, B.n_cols));
 }
 
 int LeeNewmarkBase::solve(mat& X, mat&& B) { return solve(X, B); }

--- a/suanPan.h
+++ b/suanPan.h
@@ -220,8 +220,8 @@ template<typename T> requires std::is_arithmetic_v<T> auto bcast_from_root(T obj
     return object;
 }
 
-template<mpl_data_t DT> auto& bcast_from_root(const Mat<DT>& object) {
-    comm_world.bcast(0, const_cast<DT*>(object.memptr()), mpl::contiguous_layout<DT>{object.n_elem});
+template<mpl_data_t T> auto& bcast_from_root(const Mat<T>& object) {
+    comm_world.bcast(0, const_cast<T*>(object.memptr()), mpl::contiguous_layout<T>{object.n_elem});
     return object;
 }
 
@@ -230,8 +230,13 @@ template<typename T> requires std::is_arithmetic_v<T> auto allreduce(T object) {
     return object;
 }
 
-template<mpl_data_t DT> auto& allreduce(const Mat<DT>& object) {
-    comm_world.allreduce(mpl::plus<T>(), const_cast<DT*>(object.memptr()), mpl::contiguous_layout<DT>{object.n_elem});
+template<mpl_data_t T> auto& allreduce(const Mat<T>& object) {
+    comm_world.allreduce(mpl::plus<T>(), const_cast<T*>(object.memptr()), mpl::contiguous_layout<T>{object.n_elem});
+    return object;
+}
+
+template<mpl_data_t T> auto& reduce(const Mat<T>& object) {
+    comm_world.reduce(mpl::plus<T>(), 0, const_cast<T*>(object.memptr()), mpl::contiguous_layout<T>{object.n_elem});
     return object;
 }
 #else
@@ -241,6 +246,8 @@ inline constexpr auto comm_size{1};
 template<typename T> auto bcast_from_root(T&& object) { return std::forward<T>(object); }
 
 template<typename T> auto allreduce(T&& object) { return std::forward<T>(object); }
+
+template<typename T> auto reduce(T&& object) { return std::forward<T>(object); }
 #endif
 
 #include <fmt/color.h>

--- a/suanPan.h
+++ b/suanPan.h
@@ -229,6 +229,11 @@ template<typename T> requires std::is_arithmetic_v<T> auto allreduce(T object) {
     comm_world.allreduce(mpl::plus<T>(), object);
     return object;
 }
+
+template<mpl_data_t DT> auto& allreduce(const Mat<DT>& object) {
+    comm_world.allreduce(mpl::plus<T>(), const_cast<DT*>(object.memptr()), mpl::contiguous_layout<DT>{object.n_elem});
+    return object;
+}
 #else
 inline constexpr auto comm_rank{0};
 inline constexpr auto comm_size{1};


### PR DESCRIPTION
Improve clarity and efficiency in the `Integrator` and `LeeNewmarkBase` classes by refactoring solve methods. Remove unnecessary broadcasts and unreachable code in the `Domain` class. Introduce an overloaded allreduce function for `Mat` type to support custom data types and add an allreduce method to `MetaMat` classes for enhanced functionality.