### PR TITLE
Add GERKN and WAT2 integrator implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 1. add optional hourglassing control for `CP4R` and `C3D8R` elements
 2. add `Prestrain` wrapper for uniaxial materials to apply prestrain [#266](https://github.com/TLCFEM/suanPan/pull/266)
+3. add `GERKN` generalized explicit RKN time integration [#268](https://github.com/TLCFEM/suanPan/pull/268)
 
 ## version 3.7
 

--- a/Example/Solver/WAT2.supan
+++ b/Example/Solver/WAT2.supan
@@ -31,7 +31,7 @@ set fixed_step_size 1
 set symm_mat 0
 set linear_system
 
-integrator WAT2 1
+integrator WAT2 1 1.0
 
 converger RelIncreAcc 1 1E-10 10 0
 
@@ -41,13 +41,13 @@ analyze
 # Coordinate:
 #   0.0000e+00 -5.0000e+00
 # Displacement:
-#   3.3331e+00  1.2689e+00
+#   2.5718e+00  8.0212e+00
 # Resistance:
-#  -1.8335e+06  1.2361e+06
+#   3.9778e+02  3.4848e+03
 # Velocity:
-#  -2.7069e+02  9.1303e+02
+#   3.2633e+00  2.1262e+00
 # Acceleration:
-#   3.5311e+04 -3.4846e+04
+#  -1.8685e+01 -1.7542e+02
 peek node 2 3 4
 
 peek integrator 1

--- a/Example/Solver/WAT2.supan
+++ b/Example/Solver/WAT2.supan
@@ -1,0 +1,59 @@
+node 1 0 0
+node 2 0 -2
+node 3 0 -3
+node 4 0 -5
+
+material Elastic1D 1 1E7
+
+element T2D2 1 1 2 1 1 true
+element T2D2 2 2 3 1 1 true
+element T2D2 3 3 4 1 1 true
+
+element Mass 4 1 20 1 2
+element Mass 5 2 20 1 2
+element Mass 6 3 10 1 2
+element Mass 7 4 20 1 2
+
+fix2 1 P 1
+
+initial velocity 25 1 3
+
+amplitude Constant 1
+cload 1 1 -200 2 2
+cload 2 1 -100 2 3
+cload 3 1 -200 2 4
+
+hdf5recorder 1 Node U 2 3 4
+
+step explicitdynamic 1 1
+set ini_step_size 1E-3
+set fixed_step_size 1
+set symm_mat 0
+set linear_system
+
+integrator WAT2 1
+
+converger RelIncreAcc 1 1E-10 10 0
+
+analyze
+
+# Node 4:
+# Coordinate:
+#   0.0000e+00 -5.0000e+00
+# Displacement:
+#   3.3331e+00  1.2689e+00
+# Resistance:
+#  -1.8335e+06  1.2361e+06
+# Velocity:
+#  -2.7069e+02  9.1303e+02
+# Acceleration:
+#   3.5311e+04 -3.4846e+04
+peek node 2 3 4
+
+peek integrator 1
+
+# save recorder 1
+
+reset
+clear
+exit

--- a/MSVC/suanPan/suanPan/suanPan.vcxproj
+++ b/MSVC/suanPan/suanPan/suanPan.vcxproj
@@ -504,6 +504,7 @@
     <ClCompile Include="..\..\..\Solver\Integrator\BatheTwoStep.cpp" />
     <ClCompile Include="..\..\..\Solver\Integrator\GeneralizedAlpha.cpp" />
     <ClCompile Include="..\..\..\Solver\Integrator\GeneralizedAlphaExplicit.cpp" />
+    <ClCompile Include="..\..\..\Solver\Integrator\GERKN.cpp" />
     <ClCompile Include="..\..\..\Solver\Integrator\GSSSS.cpp" />
     <ClCompile Include="..\..\..\Solver\Integrator\Integrator.cpp" />
     <ClCompile Include="..\..\..\Solver\Integrator\LeeNewmark.cpp" />
@@ -977,6 +978,7 @@
     <ClInclude Include="..\..\..\Solver\Integrator\BatheTwoStep.h" />
     <ClInclude Include="..\..\..\Solver\Integrator\GeneralizedAlpha.h" />
     <ClInclude Include="..\..\..\Solver\Integrator\GeneralizedAlphaExplicit.h" />
+    <ClInclude Include="..\..\..\Solver\Integrator\GERKN.h" />
     <ClInclude Include="..\..\..\Solver\Integrator\GSSSS.h" />
     <ClInclude Include="..\..\..\Solver\Integrator\Integrator.h" />
     <ClInclude Include="..\..\..\Solver\Integrator\LeeNewmark.h" />

--- a/MSVC/suanPan/suanPan/suanPan.vcxproj.filters
+++ b/MSVC/suanPan/suanPan/suanPan.vcxproj.filters
@@ -1588,6 +1588,9 @@
     <ClCompile Include="..\..\..\Material\Material1D\Wrapper\Prestrain.cpp">
       <Filter>Material\Material1D\Wrapper</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Solver\Integrator\GERKN.cpp">
+      <Filter>Solver\Integrator</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Constraint\BC\GroupMultiplierBC.h">
@@ -2979,6 +2982,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\Material\Material1D\Wrapper\Prestrain.h">
       <Filter>Material\Material1D\Wrapper</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Solver\Integrator\GERKN.h">
+      <Filter>Solver\Integrator</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Solver/Integrator/CMakeLists.txt
+++ b/Solver/Integrator/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(${PROJECT_NAME} PRIVATE
         BatheTwoStep.cpp
         GeneralizedAlpha.cpp
         GeneralizedAlphaExplicit.cpp
+        GERKN.cpp
         GSSSS.cpp
         Integrator.cpp
         LeeNewmark.cpp

--- a/Solver/Integrator/GERKN.cpp
+++ b/Solver/Integrator/GERKN.cpp
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (C) 2017-2025 Theodore Chang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+#include "GERKN.h"
+
+#include <Domain/DomainBase.h>
+#include <Domain/Factory.hpp>
+
+void GERKN::update_parameter(const double NT) { DT = NT; }
+
+int GERKN::process_load_impl(const bool full) {
+    auto& W = get_domain()->get_factory();
+
+    const sp_d auto trial_time = W->get_trial_time();
+
+    if(FLAG::FIRST != step_flag) W->update_incre_time((C2 - C1) * DT);
+
+    const auto code = ExplicitIntegrator::process_load_impl(full);
+
+    W->update_trial_time(trial_time);
+
+    return code;
+}
+
+int GERKN::process_constraint_impl(const bool full) {
+    auto& W = get_domain()->get_factory();
+
+    const sp_d auto trial_time = W->get_trial_time();
+
+    if(FLAG::FIRST != step_flag) W->update_incre_time((C2 - C1) * DT);
+
+    const auto code = ExplicitIntegrator::process_constraint_impl(full);
+
+    W->update_trial_time(trial_time);
+
+    return code;
+}
+
+bool GERKN::has_corrector() const { return true; }
+
+void GERKN::update_incre_time(double T) {
+    const auto& W = get_domain()->get_factory();
+    update_parameter(T *= 2.);
+    W->update_incre_time(T * (FLAG::FIRST == step_flag ? C1 : 1. - C1));
+}
+
+int GERKN::update_trial_status(bool) {
+    const auto D = get_domain();
+
+    if(auto& W = D->get_factory(); FLAG::FIRST == step_flag) {
+        W->update_incre_velocity(DT * VA10 * W->get_current_acceleration());
+        W->update_incre_displacement(DT * C1 * W->get_current_velocity() + DT * DT * UA10 * W->get_current_acceleration());
+    }
+    else {
+        W->update_incre_velocity(DT * (VA20 - VA10) * W->get_pre_acceleration() + DT * VA21 * W->get_current_acceleration());
+        W->update_incre_displacement(DT * (C2 - C1) * W->get_pre_velocity() + DT * DT * (UA20 - UA10) * W->get_pre_acceleration() + DT * DT * UA21 * W->get_current_acceleration());
+    }
+
+    return D->update_trial_status();
+}
+
+int GERKN::correct_trial_status() {
+    if(FLAG::FIRST == step_flag) return SUANPAN_SUCCESS;
+
+    const auto D = get_domain();
+    auto& W = D->get_factory();
+
+    W->update_trial_displacement(W->get_pre_displacement() + DT * W->get_pre_velocity() + DT * DT * UB0 * W->get_pre_acceleration() + DT * DT * UB1 * W->get_current_acceleration() + DT * DT * UB2 * W->get_trial_acceleration());
+    W->update_trial_velocity(W->get_pre_velocity() + DT * VB0 * W->get_pre_acceleration() + DT * VB1 * W->get_current_acceleration() + DT * VB2 * W->get_trial_acceleration());
+    W->update_trial_acceleration(AB0 * W->get_pre_acceleration() + AB1 * W->get_current_acceleration() + AB2 * W->get_trial_acceleration());
+
+    return D->update_trial_status();
+}
+
+void GERKN::commit_status() {
+    auto& W = get_domain()->get_factory();
+
+    if(FLAG::FIRST == step_flag) {
+        step_flag = FLAG::SECOND;
+        set_time_step_switch(false);
+    }
+    else {
+        step_flag = FLAG::FIRST;
+        set_time_step_switch(true);
+    }
+
+    W->commit_pre_displacement();
+    W->commit_pre_velocity();
+    W->commit_pre_acceleration();
+
+    ExplicitIntegrator::commit_status();
+}
+
+void GERKN::clear_status() {
+    step_flag = FLAG::FIRST;
+    set_time_step_switch(true);
+
+    ExplicitIntegrator::clear_status();
+}
+
+void GERKN::print() { suanpan_info("A generalized explicit RKN time integrator.\n"); }

--- a/Solver/Integrator/GERKN.cpp
+++ b/Solver/Integrator/GERKN.cpp
@@ -112,4 +112,38 @@ void GERKN::clear_status() {
     ExplicitIntegrator::clear_status();
 }
 
-void GERKN::print() { suanpan_info("A generalized explicit RKN time integrator.\n"); }
+WAT2::WAT2(const unsigned T, double R)
+    : GERKN(T) {
+    R = std::min(1., std::max(0., R));
+    R = .1 * R + .3; // [0.3,0.4]
+
+    const auto E = 2. * R - 1.;
+    const auto D = 3. * R * R - 3. * R + 1.;
+    const auto F = R * D;
+    const auto E2 = E * E;
+
+    C1 = R;
+    C2 = (3. * C1 - 2.) / 3. / E;
+
+    VA10 = C1;
+    VA21 = 2. / 9. * D / C1 / E2;
+    VA20 = C2 - VA21;
+
+    UA10 = C1 / 6.;
+    UA20 = (3. * C1 - 1.) / 18. / C1;
+    UA21 = D / 18. / C1 / E2;
+
+    VB0 = 0.;
+    VB1 = .25 / D;
+    VB2 = 1. - VB1;
+
+    UB0 = (4. * C1 - 1.) / 12. / C1;
+    UB1 = (6. * C1 * C1 - 5. * C1 + 2.) / 24. / F;
+    UB2 = .5 - UB0 - UB1;
+
+    AB0 = (1. - 3. * C1) / C1;
+    AB1 = (-3. * C1 * C1 + 4. * C1 - 1.) / F;
+    AB2 = 1. - AB0 - AB1;
+}
+
+void WAT2::print() { suanpan_info("A generalized explicit RKN time integrator using WAT2 scheme with C1={}. doi:10.1002/nme.7658\n", C1); }

--- a/Solver/Integrator/GERKN.h
+++ b/Solver/Integrator/GERKN.h
@@ -34,7 +34,7 @@
 
 #include "Integrator.h"
 
-class GERKN final : public ExplicitIntegrator {
+class GERKN : public ExplicitIntegrator {
     enum class FLAG {
         FIRST,
         SECOND
@@ -72,6 +72,11 @@ public:
 
     void commit_status() override;
     void clear_status() override;
+};
+
+class WAT2 final : public GERKN {
+public:
+    WAT2(unsigned, double);
 
     void print() override;
 };

--- a/Solver/Integrator/GERKN.h
+++ b/Solver/Integrator/GERKN.h
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (C) 2017-2025 Theodore Chang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+/**
+ * @class GERKN
+ * @brief Generalized Explicit Runge-Kutta-Nystrom time integration.
+ *
+ * References:
+ *     1. [10.1002/nme.7658](https://doi.org/10.1002/nme.7658)
+ *
+ * @author tlc
+ * @date 08/06/2025
+ * @version 0.1.0
+ * @file GERKN.h
+ * @addtogroup Integrator
+ * @{
+ */
+
+#ifndef GERKN_H
+#define GERKN_H
+
+#include "Integrator.h"
+
+class GERKN final : public ExplicitIntegrator {
+    enum class FLAG {
+        FIRST,
+        SECOND
+    };
+
+    FLAG step_flag = FLAG::FIRST;
+
+    double DT{0.};
+
+protected:
+    void update_parameter(double) override;
+
+    [[nodiscard]] int process_load_impl(bool) override;
+    [[nodiscard]] int process_constraint_impl(bool) override;
+
+    double C1{0.}, C2{0.};
+
+    double UA10{0.}, UA20{0.}, UA21{0.};
+    double UB0{0.}, UB1{0.}, UB2{0.};
+
+    double VA10{0.}, VA20{0.}, VA21{0.};
+    double VB0{0.}, VB1{0.}, VB2{0.};
+
+    double AB0{0.}, AB1{0.}, AB2{0.};
+
+public:
+    using ExplicitIntegrator::ExplicitIntegrator;
+
+    [[nodiscard]] bool has_corrector() const override;
+
+    void update_incre_time(double) override;
+
+    int update_trial_status(bool) override;
+    int correct_trial_status() override;
+
+    void commit_status() override;
+    void clear_status() override;
+
+    void print() override;
+};
+
+#endif
+
+//! @}

--- a/Solver/Integrator/Integrator
+++ b/Solver/Integrator/Integrator
@@ -1,14 +1,16 @@
 #include "Integrator.h"
 
+//
 #include "BatheExplicit.h"
 #include "BatheTwoStep.h"
+#include "GERKN.h"
+#include "GSSSS.h"
 #include "GeneralizedAlpha.h"
 #include "GeneralizedAlphaExplicit.h"
-#include "GSSSS.h"
 #include "LeeNewmark.h"
-#include "LeeNewmarkIterative.h"
 #include "LeeNewmarkBase.h"
 #include "LeeNewmarkFull.h"
+#include "LeeNewmarkIterative.h"
 #include "Newmark.h"
 #include "NonviscousNewmark.h"
 #include "OALTS.h"

--- a/Solver/SolverParser.cpp
+++ b/Solver/SolverParser.cpp
@@ -342,6 +342,15 @@ int create_new_integrator(const shared_ptr<DomainBase>& domain, std::istringstre
 
         if(domain->insert(std::make_shared<BatheExplicit>(tag, std::max(0., std::min(radius, 1.))))) code = 1;
     }
+    else if(is_equal(integrator_type, "WAT2")) {
+        auto para = 1. / 3.;
+        if(!get_optional_input(command, para)) {
+            suanpan_error("A valid parameter is required.\n");
+            return SUANPAN_SUCCESS;
+        }
+
+        if(domain->insert(std::make_shared<WAT2>(tag, std::max(std::min(1., para), 0.)))) code = 1;
+    }
     else if(is_equal(integrator_type, "GeneralizedAlphaExplicit") || is_equal(integrator_type, "GeneralisedAlphaExplicit")) {
         auto radius = .5;
         if(!get_optional_input(command, radius)) {


### PR DESCRIPTION
Introduce the GERKN and WAT2 integrator classes, enhancing the solver's capabilities. Update CMakeLists and SolverParser to support the new integrators and provide initial configuration for WAT2.