### PR TITLE
Improve logic of detecting linear systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 1. add optional hourglassing control for `CP4R` and `C3D8R` elements
 2. add `Prestrain` wrapper for uniaxial materials to apply prestrain [#266](https://github.com/TLCFEM/suanPan/pull/266)
 3. add `GERKN` generalized explicit RKN time integration [#268](https://github.com/TLCFEM/suanPan/pull/268)
+4. fix improper detection of linear systems [#270](https://github.com/TLCFEM/suanPan/pull/270)
 
 ## version 3.7
 

--- a/Example/Solver/BatheTwoStep.supan
+++ b/Example/Solver/BatheTwoStep.supan
@@ -1,33 +1,26 @@
+# A TEST MODEL FOR BATHE INTEGRATOR
+
 node 1 0 0
-node 2 0 -2
-node 3 0 -3
-node 4 0 -5
+node 2 2 0
 
-material Elastic1D 1 1E7
+material Elastic1D 1 1E4
 
-element T2D2 1 1 2 1 1 true
-element T2D2 2 2 3 1 1 true
-element T2D2 3 3 4 1 1 true
+element T2D2 1 1 2 1 1
 
 element Mass 4 2 20 1 2
-element Mass 5 3 10 1 2
-element Mass 6 4 20 1 2
 
-fix2 1 P 1
+fix2 1 1 1
+fix2 2 2 1 2
 
-initial velocity 25 1 3
+initial velocity 25 1 2
 
-amplitude Constant 1
-cload 1 1 -200 2 2
-cload 2 1 -100 2 3
-cload 3 1 -200 2 4
-
-hdf5recorder 1 Node U 2 3 4
+hdf5recorder 1 Node U 2
 
 step dynamic 1 1
 set ini_step_size 1E-2
 set fixed_step_size 1
 set symm_mat 0
+set linear_system
 
 integrator BatheTwoStep 1
 
@@ -35,17 +28,17 @@ converger RelIncreDisp 1 1E-10 10 1
 
 analyze
 
-# Node 4:
+# Node 2:
 # Coordinate:
-#   0.0000e+00 -5.0000e+00
+#   2.0000e+00  0.0000e+00
 # Displacement:
-#   1.3869e+00  7.4423e+00
+#  -6.0118e-02  0.0000e+00
 # Resistance:
-#  -1.3947e+01  8.7934e+01
+#  -3.0059e+02  0.0000e+00
 # Velocity:
-#   1.4165e+00  1.3658e+00
+#  -2.4939e+01  0.0000e+00
 # Acceleration:
-#   6.9734e-01 -1.4397e+01
+#   1.5030e+01  0.0000e+00
 peek node 2 3 4
 
 peek integrator 1

--- a/Solver/Integrator/BatheExplicit.cpp
+++ b/Solver/Integrator/BatheExplicit.cpp
@@ -29,6 +29,8 @@ BatheExplicit::BatheExplicit(const unsigned T, const double R)
 
 bool BatheExplicit::has_corrector() const { return true; }
 
+bool BatheExplicit::time_independent_matrix() const { return false; }
+
 void BatheExplicit::update_incre_time(double T) {
     const auto& W = get_domain()->get_factory();
     update_parameter(T *= 2.);

--- a/Solver/Integrator/BatheExplicit.h
+++ b/Solver/Integrator/BatheExplicit.h
@@ -49,6 +49,7 @@ public:
     BatheExplicit(unsigned, double);
 
     [[nodiscard]] bool has_corrector() const override;
+    [[nodiscard]] bool time_independent_matrix() const override;
 
     void update_incre_time(double) override;
 

--- a/Solver/Integrator/BatheTwoStep.cpp
+++ b/Solver/Integrator/BatheTwoStep.cpp
@@ -27,6 +27,8 @@ BatheTwoStep::BatheTwoStep(const unsigned T, const double R, const double G)
     , Q2(.5 - GM * Q1)
     , Q0(1. - Q1 - Q2) {}
 
+bool BatheTwoStep::time_independent_matrix() const { return false; }
+
 void BatheTwoStep::assemble_resistance() {
     const auto D = get_domain();
     auto& W = D->get_factory();

--- a/Solver/Integrator/BatheTwoStep.h
+++ b/Solver/Integrator/BatheTwoStep.h
@@ -51,6 +51,8 @@ protected:
 public:
     BatheTwoStep(unsigned, double, double);
 
+    [[nodiscard]] bool time_independent_matrix() const override;
+
     void assemble_resistance() override;
     void assemble_matrix() override;
 

--- a/Solver/Integrator/GERKN.cpp
+++ b/Solver/Integrator/GERKN.cpp
@@ -52,6 +52,8 @@ int GERKN::process_constraint_impl(const bool full) {
 
 bool GERKN::has_corrector() const { return true; }
 
+bool GERKN::time_independent_matrix() const { return false; }
+
 void GERKN::update_incre_time(double T) {
     const auto& W = get_domain()->get_factory();
     update_parameter(T *= 2.);

--- a/Solver/Integrator/GERKN.h
+++ b/Solver/Integrator/GERKN.h
@@ -64,6 +64,7 @@ public:
     using ExplicitIntegrator::ExplicitIntegrator;
 
     [[nodiscard]] bool has_corrector() const override;
+    [[nodiscard]] bool time_independent_matrix() const override;
 
     void update_incre_time(double) override;
 

--- a/Solver/Integrator/Integrator.cpp
+++ b/Solver/Integrator/Integrator.cpp
@@ -67,6 +67,12 @@ bool Integrator::matrix_is_assembled() const { return matrix_assembled_switch; }
 
 bool Integrator::has_corrector() const { return false; }
 
+/**
+ * Indicate whether the matrix is independent of time, that is, the system does not change with time.
+ * This helps to determine whether the matrix needs to be reassembled.
+ * For single-step methods, it is typically true.
+ * For multistep methods, it is typically false.
+ */
 bool Integrator::time_independent_matrix() const { return true; }
 
 int Integrator::process_load() { return process_load_impl(true); }

--- a/Solver/Solver.cpp
+++ b/Solver/Solver.cpp
@@ -58,8 +58,8 @@ bool Solver::constant_matrix() const {
 
     // need to satisfy a number of conditions:
     // 1. fixed step size
-    // 2. if not fixed step size, the effective stiffness needs to be independent from time
+    // 2. the effective stiffness needs to be independent of time
     // 3. the system needs to be linear
     // 4. the effective stiffness has been assembled
-    return (S->is_fixed_step_size() || G->time_independent_matrix()) && D->get_attribute(ModalAttribute::LinearSystem) && G->matrix_is_assembled();
+    return S->is_fixed_step_size() && G->time_independent_matrix() && D->get_attribute(ModalAttribute::LinearSystem) && G->matrix_is_assembled();
 }


### PR DESCRIPTION
1. Explicitly state all multistep methods do not have time independent matrices.
2. Linear systems need to have fixed step size AND time independent matrices.