### PR TITLE
Add unsigned artifact upload and signing steps to workflow

### DIFF
--- a/.github/workflows/dev-all.yml
+++ b/.github/workflows/dev-all.yml
@@ -346,6 +346,24 @@ jobs:
           [[ "${{ matrix.vtk }}" == "ON" ]] && file_name+="-vtk"
           file_name+=".zip"
           echo "ARTIFACT=$file_name" >> "$GITHUB_ENV"
+      - name: Unsigned
+        if: ${{ github.event_name == 'push' }}
+        id: upload-unsigned-vs
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-${{ env.ARTIFACT }}
+          path: build/dist/bin/*.exe
+      - name: Sign
+        if: ${{ github.event_name == 'push' }}
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          api-token: "${{ secrets.SIGNPATH }}"
+          organization-id: "b04bac88-d6e9-4140-948d-cb95e3095cbe"
+          project-slug: "suanPan"
+          signing-policy-slug: "test-signing"
+          github-artifact-id: "${{ steps.upload-unsigned-vs.outputs.artifact-id }}"
+          wait-for-completion: true
+          output-artifact-directory: "build/dist/bin"
       - name: Pack
         shell: bash
         run: |
@@ -413,6 +431,24 @@ jobs:
           [[ "${{ matrix.vtk }}" == "ON" ]] && file_name+="-vtk"
           file_name+=".zip"
           echo "ARTIFACT=$file_name" >> "$GITHUB_ENV"
+      - name: Unsigned
+        if: ${{ github.event_name == 'push' }}
+        id: upload-unsigned-gcc
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-${{ env.ARTIFACT }}
+          path: build/dist/bin/*.exe
+      - name: Sign
+        if: ${{ github.event_name == 'push' }}
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          api-token: "${{ secrets.SIGNPATH }}"
+          organization-id: "b04bac88-d6e9-4140-948d-cb95e3095cbe"
+          project-slug: "suanPan"
+          signing-policy-slug: "test-signing"
+          github-artifact-id: "${{ steps.upload-unsigned-gcc.outputs.artifact-id }}"
+          wait-for-completion: true
+          output-artifact-directory: "build/dist/bin"
       - name: Pack
         shell: bash
         run: |

--- a/.github/workflows/master-all.yml
+++ b/.github/workflows/master-all.yml
@@ -320,6 +320,24 @@ jobs:
           [[ "${{ matrix.avx }}" == "OFF" ]] && file_name+="-no-avx"
           file_name+=".zip"
           echo "ARTIFACT=$file_name" >> "$GITHUB_ENV"
+      - name: Unsigned
+        if: ${{ github.event_name == 'push' }}
+        id: upload-unsigned-vs
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-${{ env.ARTIFACT }}
+          path: build/dist/bin/*.exe
+      - name: Sign
+        if: ${{ github.event_name == 'push' }}
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          api-token: "${{ secrets.SIGNPATH }}"
+          organization-id: "b04bac88-d6e9-4140-948d-cb95e3095cbe"
+          project-slug: "suanPan"
+          signing-policy-slug: "release-signing"
+          github-artifact-id: "${{ steps.upload-unsigned-vs.outputs.artifact-id }}"
+          wait-for-completion: true
+          output-artifact-directory: "build/dist/bin"
       - name: Pack
         shell: bash
         run: |
@@ -426,6 +444,24 @@ jobs:
           [[ "${{ matrix.avx }}" == "OFF" ]] && file_name+="-no-avx"
           file_name+=".zip"
           echo "ARTIFACT=$file_name" >> "$GITHUB_ENV"
+      - name: Unsigned
+        if: ${{ github.event_name == 'push' }}
+        id: upload-unsigned-gcc
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-${{ env.ARTIFACT }}
+          path: build/dist/bin/*.exe
+      - name: Sign
+        if: ${{ github.event_name == 'push' }}
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          api-token: "${{ secrets.SIGNPATH }}"
+          organization-id: "b04bac88-d6e9-4140-948d-cb95e3095cbe"
+          project-slug: "suanPan"
+          signing-policy-slug: "release-signing"
+          github-artifact-id: "${{ steps.upload-unsigned-gcc.outputs.artifact-id }}"
+          wait-for-completion: true
+          output-artifact-directory: "build/dist/bin"
       - name: Pack
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -124,11 +124,6 @@ The archives of binaries are released under [Release](https://github.com/TLCFEM/
 1. `suanpan-win-mkl-vtk.zip` is the portable archive.
 2. `suanpan-win-mkl-vtk.exe` is the installer.
 
-> [!NOTE]
-> The executables are **not** signed.
-> Windows Defender SmartScreen may block execution.
-> Click `More info` -> `Run anyway` to execute the application.
-
 #### Chocolatey
 
 The binaries, which are compiled with Intel MKL and VTK, are available
@@ -165,6 +160,14 @@ It is also possible to use [Scoop](https://scoop.sh/) to install the package.
    ```ps
    scoop install suanpan
    ```
+
+### Code Signing Policy
+
+[![SignPath](https://raw.githubusercontent.com/SignPath/fdn-website/refs/heads/main/docs/assets/logo.svg)](https://about.signpath.io/)
+
+Free code signing provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).
+
+This program will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it.
 
 ### Linux
 


### PR DESCRIPTION
Introduce steps to upload an unsigned artifact and submit a signing request in the workflow. This enhances the build process by ensuring artifacts are properly signed.