### PR TITLE
Fix OpenBLAS library copying in mac-dependency.sh

### DIFF
--- a/.github/workflows/dev-all.yml
+++ b/.github/workflows/dev-all.yml
@@ -297,7 +297,7 @@ jobs:
           tar czf $file_name -C build/dist .
       - name: Test
         run: |
-          export DYLD_LIBRARY_PATH="/Users/runner/work/suanPan/suanPan/build/dist/lib/;$(brew --prefix gcc@13)/lib/gcc/13/
+          export DYLD_LIBRARY_PATH="/Users/runner/work/suanPan/suanPan/build/dist/lib/;$(brew --prefix gcc@13)/lib/gcc/13/"
           ./build/dist/bin/suanPan -v
       - name: Upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/dev-all.yml
+++ b/.github/workflows/dev-all.yml
@@ -297,7 +297,7 @@ jobs:
           tar czf $file_name -C build/dist .
       - name: Test
         run: |
-          export DYLD_LIBRARY_PATH=/Users/runner/work/suanPan/suanPan/build/dist/lib/
+          export DYLD_LIBRARY_PATH="/Users/runner/work/suanPan/suanPan/build/dist/lib/;$(brew --prefix gcc@13)/lib/gcc/13/
           ./build/dist/bin/suanPan -v
       - name: Upload
         uses: actions/upload-artifact@v4

--- a/Script/mac-dependency.sh
+++ b/Script/mac-dependency.sh
@@ -80,8 +80,8 @@ TMP_DIR="$(mktemp -d)"
 wget -q -O "$TMP_DIR/archive.tar.gz" "$TARBALL_URL"
 tar -xzf "$TMP_DIR/archive.tar.gz" -C "$TMP_DIR"
 
-find "$TMP_DIR" -name "*.dylib" -exec cp -P {} "$TARGET_DIR" \;
-# cp "$TMP_DIR/libopenblas.a" "$TARGET_DIR"
+# find "$TMP_DIR" -name "*.dylib" -exec cp -P {} "$TARGET_DIR" \;
+cp "$TMP_DIR/libopenblas.a" "$TARGET_DIR"
 
 rm -rf "$TMP_DIR"
 


### PR DESCRIPTION
Correct the copying process for the OpenBLAS library by ensuring the static library is copied instead of the dynamic libraries.