### PR TITLE
Enhance stiffness calculation and matrix assembly in LeeNewmark integrator

### DIFF
--- a/Constraint/BC.cpp
+++ b/Constraint/BC.cpp
@@ -31,7 +31,20 @@ PenaltyBC::PenaltyBC(const unsigned T, uvec&& N, std::vector<Node::DOF>&& D)
  * It effectively adds a diagonal matrix to the global stiffness matrix.
  */
 int PenaltyBC::process(const shared_ptr<DomainBase>& D) {
-    stiffness.zeros(target_node_dof.n_elem, target_node_dof.n_elem).diag().fill(multiplier * D->get_factory()->get_stiffness()->max());
+    auto& W = D->get_factory();
+
+    double reference{0.};
+    if(Integrator::Type::Explicit == D->get_current_step()->get_integrator()->type()) reference = W->get_mass()->max();
+    else {
+        const auto incre_time = W->get_incre_time();
+        if(auto& t_mat = W->get_stiffness()) reference += t_mat->max();
+        if(auto& t_mat = W->get_geometry()) reference += t_mat->max();
+        if(auto& t_mat = W->get_damping()) reference += t_mat->max() / incre_time;
+        if(auto& t_mat = W->get_nonviscous()) reference += t_mat->max() / incre_time;
+        if(auto& t_mat = W->get_mass()) reference += t_mat->max() / incre_time / incre_time;
+    }
+
+    stiffness.zeros(target_node_dof.n_elem, target_node_dof.n_elem).diag().fill(multiplier * reference);
 
     return process_resistance(D);
 }

--- a/Solver/Integrator/Implicit/LeeNewmark/LeeNewmark.cpp
+++ b/Solver/Integrator/Implicit/LeeNewmark/LeeNewmark.cpp
@@ -100,6 +100,9 @@ int LeeNewmark::process_constraint() {
     // process constraint for the first time to obtain proper stiffness
     if(SUANPAN_SUCCESS != LeeNewmarkBase::process_constraint()) return SUANPAN_FAIL;
 
+    // !!! need to call the parent method to have effective matrix assembled
+    LeeNewmarkBase::assemble_effective_matrix();
+
     // this stiffness contains geometry, mass and damping which are handled in Newmark::assemble_matrix()
     auto& t_stiff = factory->modify_stiffness();
 
@@ -167,6 +170,12 @@ void LeeNewmark::assemble_resistance() {
 
     W->set_sushi(W->get_trial_resistance() + W->get_trial_damping_force() + W->get_trial_nonviscous_force() + W->get_trial_inertial_force());
 }
+
+/**
+ * We are not interested in the original matrices anymore.
+ * Thus, we skip assembling them.
+ */
+void LeeNewmark::assemble_effective_matrix() {}
 
 void LeeNewmark::print() {
     suanpan_info("A Newmark solver using Lee's damping model. doi:10.1016/j.jsv.2020.115312\n");

--- a/Solver/Integrator/Implicit/LeeNewmark/LeeNewmark.h
+++ b/Solver/Integrator/Implicit/LeeNewmark/LeeNewmark.h
@@ -64,6 +64,7 @@ public:
     int process_constraint_resistance() override;
 
     void assemble_resistance() override;
+    void assemble_effective_matrix() override;
 
     void print() override;
 };

--- a/Solver/Integrator/Implicit/LeeNewmark/LeeNewmarkFull.cpp
+++ b/Solver/Integrator/Implicit/LeeNewmark/LeeNewmarkFull.cpp
@@ -362,6 +362,8 @@ int LeeNewmarkFull::process_constraint() {
     // process constraint for the first time to obtain proper stiffness
     if(SUANPAN_SUCCESS != LeeNewmarkBase::process_constraint()) return SUANPAN_FAIL;
 
+    LeeNewmarkBase::assemble_effective_matrix();
+
     // this stiffness contains geometry, mass and damping from Newmark::assemble_matrix()
     auto& t_stiff = factory->get_stiffness()->triplet_mat;
 

--- a/Solver/Integrator/Implicit/LeeNewmark/LeeNewmarkFull.cpp
+++ b/Solver/Integrator/Implicit/LeeNewmark/LeeNewmarkFull.cpp
@@ -522,6 +522,12 @@ int LeeNewmarkFull::process_constraint_resistance() {
     return LeeNewmarkBase::process_constraint_resistance();
 }
 
+/**
+ * We are not interested in the original matrices anymore.
+ * Thus, we skip assembling them.
+ */
+void LeeNewmarkFull::assemble_effective_matrix() {}
+
 void LeeNewmarkFull::print() {
     // clang-format off
     suanpan_info("A Newmark solver using Lee's damping model with adjustable bandwidth using {} stiffness. doi:10.1016/j.compstruc.2020.106423 and 10.1016/j.compstruc.2021.106663\n", stiffness_type == StiffnessType::TRIAL ? "tangent" : stiffness_type == StiffnessType::CURRENT ? "converged" : "initial");

--- a/Solver/Integrator/Implicit/LeeNewmark/LeeNewmarkFull.h
+++ b/Solver/Integrator/Implicit/LeeNewmark/LeeNewmarkFull.h
@@ -93,6 +93,8 @@ public:
     int process_constraint() override;
     int process_constraint_resistance() override;
 
+    void assemble_effective_matrix() override;
+
     void print() override;
 };
 


### PR DESCRIPTION
Improve the PenaltyBC process method to dynamically calculate stiffness based on the integrator type and matrix contributions. Implement effective matrix assembly in the LeeNewmark integrator and ensure it is called during the constraint processing.