### PR TITLE
Refactor ConditionalModifier and enhance Load/Constraint classes

### DIFF
--- a/Constraint/BC.cpp
+++ b/Constraint/BC.cpp
@@ -29,7 +29,7 @@ PenaltyBC::PenaltyBC(const unsigned T, uvec&& N, std::vector<Node::DOF>&& D)
 int PenaltyBC::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
 
-    target_node_dof = collect_node_dof(D);
+    target_dof = collect_node_dof(D);
 
     return SUANPAN_SUCCESS;
 }
@@ -54,14 +54,14 @@ int PenaltyBC::process(const shared_ptr<DomainBase>& D) {
         if(auto& t_mat = W->get_mass()) reference += t_mat->max() / incre_time / incre_time;
     }
 
-    stiffness.zeros(target_node_dof.n_elem, target_node_dof.n_elem).diag().fill(multiplier * reference);
+    stiffness.zeros(target_dof.n_elem, target_dof.n_elem).diag().fill(multiplier * reference);
 
     return process_resistance(D);
 }
 
 int PenaltyBC::process_resistance(const shared_ptr<DomainBase>& D) {
     // this ensures all restrained DoFs have zero displacement in modified Newton methods
-    D->insert_constrained_dof(target_node_dof);
+    D->insert_constrained_dof(target_dof);
 
     return SUANPAN_SUCCESS;
 }
@@ -77,29 +77,29 @@ int MultiplierBC::process(const shared_ptr<DomainBase>& D) {
     if(Integrator::Type::Explicit == D->get_current_step()->get_integrator()->type()) {
         if(auto& t_mass = W->get_mass()) {
             std::scoped_lock lock(W->get_mass_mutex());
-            t_mass->unify(target_node_dof);
+            t_mass->unify(target_dof);
         }
     }
     else {
         if(auto& t_stiff = W->get_stiffness()) {
             std::scoped_lock lock(W->get_stiffness_mutex());
-            t_stiff->unify(target_node_dof);
+            t_stiff->unify(target_dof);
         }
         if(auto& t_mass = W->get_mass()) {
             std::scoped_lock lock(W->get_mass_mutex());
-            t_mass->nullify(target_node_dof);
+            t_mass->nullify(target_dof);
         }
         if(auto& t_damping = W->get_damping()) {
             std::scoped_lock lock(W->get_damping_mutex());
-            t_damping->nullify(target_node_dof);
+            t_damping->nullify(target_dof);
         }
         if(auto& t_nonviscous = W->get_nonviscous()) {
             std::scoped_lock lock(W->get_nonviscous_mutex());
-            t_nonviscous->nullify(target_node_dof);
+            t_nonviscous->nullify(target_dof);
         }
         if(auto& t_geometry = W->get_geometry()) {
             std::scoped_lock lock(W->get_geometry_mutex());
-            t_geometry->nullify(target_node_dof);
+            t_geometry->nullify(target_dof);
         }
     }
 

--- a/Constraint/BC.cpp
+++ b/Constraint/BC.cpp
@@ -26,6 +26,14 @@ double PenaltyBC::multiplier = 1E8;
 PenaltyBC::PenaltyBC(const unsigned T, uvec&& N, std::vector<Node::DOF>&& D)
     : Constraint(T, 0, {}, std::move(D), 0) { target_node = std::move(N); }
 
+int PenaltyBC::initialize(const shared_ptr<DomainBase>& D) {
+    if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
+
+    target_node_dof = collect_node_dof(D);
+
+    return SUANPAN_SUCCESS;
+}
+
 /**
  * \brief Apply the BC to the system using penalty method.
  * It effectively adds a diagonal matrix to the global stiffness matrix.

--- a/Constraint/BC.h
+++ b/Constraint/BC.h
@@ -45,14 +45,14 @@ class PenaltyBC : public Constraint {
 
     friend void set_constraint_multiplier(double);
 
-    [[nodiscard]] bool collect_node() const final { return true; }
-
 public:
     PenaltyBC(
         unsigned,
         uvec&&,                  // node tags
         std::vector<Node::DOF>&& // dof components
     );
+
+    int initialize(const shared_ptr<DomainBase>&) override;
 
     int process(const shared_ptr<DomainBase>&) override;
     int process_resistance(const shared_ptr<DomainBase>&) final;

--- a/Constraint/BC.h
+++ b/Constraint/BC.h
@@ -45,6 +45,8 @@ class PenaltyBC : public Constraint {
 
     friend void set_constraint_multiplier(double);
 
+    [[nodiscard]] bool collect_node() const final { return true; }
+
 public:
     PenaltyBC(
         unsigned,

--- a/Constraint/Embed.h
+++ b/Constraint/Embed.h
@@ -38,9 +38,6 @@ template<unsigned DIM> class Embed final : public Constraint {
     static constexpr unsigned max_iteration = 20u;
     static constexpr double tolerance = 1E-14;
 
-    [[nodiscard]] bool validate_node() const override { return true; }
-    [[nodiscard]] bool validate_element() const override { return true; }
-
 public:
     Embed(const unsigned T, const unsigned ET, const unsigned NT)
         : Constraint(T, 0, suanpan::translational(DIM), {}, DIM) {
@@ -50,6 +47,9 @@ public:
 
     int initialize(const shared_ptr<DomainBase>& D) override {
         if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
+
+        if(!validate_node_impl(D)) return SUANPAN_FAIL;
+        if(!validate_element_impl(D)) return SUANPAN_FAIL;
 
         auto& t_node = D->get<Node>(target_node(0));
         auto& t_element = D->get<Element>(target_element(0));

--- a/Constraint/Embed.h
+++ b/Constraint/Embed.h
@@ -48,8 +48,8 @@ public:
     int initialize(const shared_ptr<DomainBase>& D) override {
         if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
 
-        if(!validate_node_impl(D)) return SUANPAN_FAIL;
-        if(!validate_element_impl(D)) return SUANPAN_FAIL;
+        if(!validate_node(D)) return SUANPAN_FAIL;
+        if(!validate_element(D)) return SUANPAN_FAIL;
 
         auto& t_node = D->get<Node>(target_node(0));
         auto& t_element = D->get<Element>(target_element(0));

--- a/Constraint/FixedLength.h
+++ b/Constraint/FixedLength.h
@@ -53,7 +53,7 @@ public:
 
         if(!validate_node(D)) return SUANPAN_FAIL;
 
-        target_node_dof = collect_node_dof(D);
+        target_dof = collect_node_dof(D);
 
         initial_chord = D->get<Node>(target_node(1))->initial_position(DIM) - D->get<Node>(target_node(0))->initial_position(DIM);
 
@@ -65,7 +65,7 @@ public:
     int process(const shared_ptr<DomainBase>& D) override {
         auto& W = D->get_factory();
 
-        const uvec dof_i = target_node_dof.head(DIM), dof_j = target_node_dof.tail(DIM);
+        const uvec dof_i = target_dof.head(DIM), dof_j = target_dof.tail(DIM);
 
         const vec t_disp = W->get_trial_displacement()(dof_j) - W->get_trial_displacement()(dof_i);
         const vec t_chord = initial_chord + t_disp;
@@ -97,7 +97,7 @@ public:
             auxiliary_resistance += t_disp(I) * (2. * initial_chord(I) + t_disp(I));
         }
 
-        stiffness.zeros(target_node_dof.n_elem, target_node_dof.n_elem);
+        stiffness.zeros(target_dof.n_elem, target_dof.n_elem);
         const auto t_factor = 2. * trial_lambda(0);
         for(auto I = 0u; I < DIM; ++I) stiffness(I + DIM, I) = stiffness(I, I + DIM) = -(stiffness(I, I) = stiffness(I + DIM, I + DIM) = t_factor);
 
@@ -193,7 +193,7 @@ public:
         if(0u == FixedLength<DIM>::lagrangian_size) return SUANPAN_SUCCESS;
 
         vec nodal_resistance(DIM);
-        for(auto I = 0u; I < DIM; ++I) nodal_resistance(I) = FixedLength<DIM>::resistance(FixedLength<DIM>::target_node_dof(I));
+        for(auto I = 0u; I < DIM; ++I) nodal_resistance(I) = FixedLength<DIM>::resistance(FixedLength<DIM>::target_dof(I));
 
         if(norm(nodal_resistance) > max_force) {
             trial_flag = true;

--- a/Constraint/FixedLength.h
+++ b/Constraint/FixedLength.h
@@ -51,7 +51,7 @@ public:
     int initialize(const shared_ptr<DomainBase>& D) override {
         if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
 
-        if(!validate_node_impl(D)) return SUANPAN_FAIL;
+        if(!validate_node(D)) return SUANPAN_FAIL;
 
         target_node_dof = collect_node_dof(D);
 

--- a/Constraint/FixedLength.h
+++ b/Constraint/FixedLength.h
@@ -41,6 +41,7 @@ template<unsigned DIM> class FixedLength : public Constraint {
     vec initial_chord;
 
     [[nodiscard]] bool validate_node() const final { return true; }
+    [[nodiscard]] bool collect_node() const final { return true; }
 
 protected:
     bool min_bound = false, max_bound = false;

--- a/Constraint/FixedLength.h
+++ b/Constraint/FixedLength.h
@@ -54,6 +54,7 @@ public:
         if(!validate_node_impl(D)) return SUANPAN_FAIL;
 
         target_node_dof = collect_node_dof(D);
+
         initial_chord = D->get<Node>(target_node(1))->initial_position(DIM) - D->get<Node>(target_node(0))->initial_position(DIM);
 
         set_multiplier_size(0u);

--- a/Constraint/FixedLength.h
+++ b/Constraint/FixedLength.h
@@ -40,9 +40,6 @@
 template<unsigned DIM> class FixedLength : public Constraint {
     vec initial_chord;
 
-    [[nodiscard]] bool validate_node() const final { return true; }
-    [[nodiscard]] bool collect_node() const final { return true; }
-
 protected:
     bool min_bound = false, max_bound = false;
     double min_gap = 0., max_gap = 0.;
@@ -54,6 +51,9 @@ public:
     int initialize(const shared_ptr<DomainBase>& D) override {
         if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
 
+        if(!validate_node_impl(D)) return SUANPAN_FAIL;
+
+        target_node_dof = collect_node_dof(D);
         initial_chord = D->get<Node>(target_node(1))->initial_position(DIM) - D->get<Node>(target_node(0))->initial_position(DIM);
 
         set_multiplier_size(0u);

--- a/Constraint/MolecularDynamics.h
+++ b/Constraint/MolecularDynamics.h
@@ -39,8 +39,6 @@ template<unsigned DIM, bool ROTATION> class MolecularDynamics : public Constrain
     uvec interaction_tags;
     std::vector<shared_ptr<Interaction>> interactions;
 
-    [[nodiscard]] bool validate_node() const final { return true; }
-
 protected:
     std::vector<shared_ptr<Element>> elements;
     double space = 0.;
@@ -83,7 +81,11 @@ public:
 
         space = 2. * std::transform_reduce(elements.cbegin(), elements.cend(), 0., [](const double a, const double b) { return std::max(a, b); }, [](const std::shared_ptr<Element>& element) { return element->get(Element::Parameter::RADIUS); });
 
-        return Constraint::initialize(D);
+        if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
+
+        if(!validate_node_impl(D)) return SUANPAN_FAIL;
+
+        return SUANPAN_SUCCESS;
     }
 
     int process(const shared_ptr<DomainBase>& D) override { return process_entrypoint(D, true); }

--- a/Constraint/MolecularDynamics.h
+++ b/Constraint/MolecularDynamics.h
@@ -83,7 +83,7 @@ public:
 
         if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
 
-        if(!validate_node_impl(D)) return SUANPAN_FAIL;
+        if(!validate_node(D)) return SUANPAN_FAIL;
 
         return SUANPAN_SUCCESS;
     }

--- a/Constraint/NodeFacet.cpp
+++ b/Constraint/NodeFacet.cpp
@@ -24,9 +24,14 @@ NodeFacet::NodeFacet(const unsigned T, const unsigned A, uvec&& N)
     : Constraint(T, A, {Node::DOF::U1, Node::DOF::U2, Node::DOF::U3}, {}, 1) { target_node = std::move(N); }
 
 int NodeFacet::initialize(const shared_ptr<DomainBase>& D) {
+    if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
+
+    if(!validate_node_impl(D)) return SUANPAN_FAIL;
+    target_node_dof = collect_node_dof(D);
+
     set_multiplier_size(0u);
 
-    return Constraint::initialize(D);
+    return SUANPAN_SUCCESS;
 }
 
 int NodeFacet::process(const shared_ptr<DomainBase>& D) {

--- a/Constraint/NodeFacet.cpp
+++ b/Constraint/NodeFacet.cpp
@@ -26,7 +26,7 @@ NodeFacet::NodeFacet(const unsigned T, const unsigned A, uvec&& N)
 int NodeFacet::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
 
-    if(!validate_node_impl(D)) return SUANPAN_FAIL;
+    if(!validate_node(D)) return SUANPAN_FAIL;
 
     target_node_dof = collect_node_dof(D);
 

--- a/Constraint/NodeFacet.cpp
+++ b/Constraint/NodeFacet.cpp
@@ -28,7 +28,7 @@ int NodeFacet::initialize(const shared_ptr<DomainBase>& D) {
 
     if(!validate_node(D)) return SUANPAN_FAIL;
 
-    target_node_dof = collect_node_dof(D);
+    target_dof = collect_node_dof(D);
 
     set_multiplier_size(0u);
 
@@ -67,10 +67,10 @@ int NodeFacet::process(const shared_ptr<DomainBase>& D) {
     const rowvec dpdk = s_i.t() * skew_edge_k;
 
     for(auto I = 0, J = 3, K = 6, L = 9; I < 3; ++I, ++J, ++K, ++L) {
-        auxiliary_stiffness(target_node_dof(I)) = dpdi(I);
-        auxiliary_stiffness(target_node_dof(J)) = dpdj(I);
-        auxiliary_stiffness(target_node_dof(K)) = dpdk(I);
-        auxiliary_stiffness(target_node_dof(L)) = outer_normal(I);
+        auxiliary_stiffness(target_dof(I)) = dpdi(I);
+        auxiliary_stiffness(target_dof(J)) = dpdj(I);
+        auxiliary_stiffness(target_dof(K)) = dpdk(I);
+        auxiliary_stiffness(target_dof(L)) = outer_normal(I);
     }
 
     skew_edge_i *= trial_lambda(0);
@@ -79,7 +79,7 @@ int NodeFacet::process(const shared_ptr<DomainBase>& D) {
 
     const auto skew_s_i = transform::skew_symm(s_i *= trial_lambda(0));
 
-    stiffness.zeros(target_node_dof.n_elem, target_node_dof.n_elem);
+    stiffness.zeros(target_dof.n_elem, target_dof.n_elem);
     stiffness(span_i, span_j) = -(stiffness(span_j, span_i) = skew_s_i + skew_edge_j);
     stiffness(span_i, span_k) = -(stiffness(span_k, span_i) = skew_edge_k - skew_s_i);
     stiffness(span_j, span_k) = -(stiffness(span_k, span_j) = skew_s_i);

--- a/Constraint/NodeFacet.cpp
+++ b/Constraint/NodeFacet.cpp
@@ -27,6 +27,7 @@ int NodeFacet::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
 
     if(!validate_node_impl(D)) return SUANPAN_FAIL;
+
     target_node_dof = collect_node_dof(D);
 
     set_multiplier_size(0u);

--- a/Constraint/NodeFacet.h
+++ b/Constraint/NodeFacet.h
@@ -34,9 +34,6 @@
 #include "Constraint.h"
 
 class NodeFacet final : public Constraint {
-    [[nodiscard]] bool validate_node() const override { return true; }
-    [[nodiscard]] bool collect_node() const override { return true; }
-
 public:
     NodeFacet(unsigned, unsigned, uvec&&);
 

--- a/Constraint/NodeFacet.h
+++ b/Constraint/NodeFacet.h
@@ -35,6 +35,7 @@
 
 class NodeFacet final : public Constraint {
     [[nodiscard]] bool validate_node() const override { return true; }
+    [[nodiscard]] bool collect_node() const override { return true; }
 
 public:
     NodeFacet(unsigned, unsigned, uvec&&);

--- a/Constraint/NodeLine.cpp
+++ b/Constraint/NodeLine.cpp
@@ -30,6 +30,9 @@ NodeLine::NodeLine(const unsigned T, const unsigned A, uvec&& N)
 int NodeLine::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
 
+    if(!validate_node_impl(D)) return SUANPAN_FAIL;
+
+    target_node_dof = collect_node_dof(D);
     set_multiplier_size(0u);
 
     const auto node_i = D->get<Node>(target_node(0))->initial_position(2u);

--- a/Constraint/NodeLine.cpp
+++ b/Constraint/NodeLine.cpp
@@ -32,7 +32,7 @@ int NodeLine::initialize(const shared_ptr<DomainBase>& D) {
 
     if(!validate_node(D)) return SUANPAN_FAIL;
 
-    target_node_dof = collect_node_dof(D);
+    target_dof = collect_node_dof(D);
 
     set_multiplier_size(0u);
 
@@ -69,16 +69,16 @@ int NodeLine::process(const shared_ptr<DomainBase>& D) {
     const rowvec dpdj = position.t() * rotation;
 
     for(auto I = 0, J = 2, K = 4; I < 2; ++I, ++J, ++K) {
-        auxiliary_stiffness(target_node_dof(I)) = dpdi(I);
-        auxiliary_stiffness(target_node_dof(J)) = dpdj(I);
-        auxiliary_stiffness(target_node_dof(K)) = outer_normal(I);
+        auxiliary_stiffness(target_dof(I)) = dpdi(I);
+        auxiliary_stiffness(target_dof(J)) = dpdj(I);
+        auxiliary_stiffness(target_dof(K)) = outer_normal(I);
     }
 
     if(initial_right) auxiliary_stiffness *= -1.;
 
     const mat factor = (initial_right ? -trial_lambda(0) : trial_lambda(0)) * rotation;
 
-    stiffness.zeros(target_node_dof.n_elem, target_node_dof.n_elem);
+    stiffness.zeros(target_dof.n_elem, target_dof.n_elem);
     stiffness(span_i, span_i) = factor.t() + factor;
     stiffness(span_i, span_j) = stiffness(span_k, span_i) = -(stiffness(span_k, span_j) = factor);
     stiffness(span_i, span_k) = stiffness(span_j, span_i) = -(stiffness(span_j, span_k) = factor.t());

--- a/Constraint/NodeLine.cpp
+++ b/Constraint/NodeLine.cpp
@@ -33,6 +33,7 @@ int NodeLine::initialize(const shared_ptr<DomainBase>& D) {
     if(!validate_node_impl(D)) return SUANPAN_FAIL;
 
     target_node_dof = collect_node_dof(D);
+
     set_multiplier_size(0u);
 
     const auto node_i = D->get<Node>(target_node(0))->initial_position(2u);

--- a/Constraint/NodeLine.cpp
+++ b/Constraint/NodeLine.cpp
@@ -30,7 +30,7 @@ NodeLine::NodeLine(const unsigned T, const unsigned A, uvec&& N)
 int NodeLine::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
 
-    if(!validate_node_impl(D)) return SUANPAN_FAIL;
+    if(!validate_node(D)) return SUANPAN_FAIL;
 
     target_node_dof = collect_node_dof(D);
 

--- a/Constraint/NodeLine.h
+++ b/Constraint/NodeLine.h
@@ -40,6 +40,7 @@ class NodeLine final : public Constraint {
     bool initial_right{true};
 
     [[nodiscard]] bool validate_node() const override { return true; }
+    [[nodiscard]] bool collect_node() const override { return true; }
 
 public:
     NodeLine(unsigned, unsigned, uvec&&);

--- a/Constraint/NodeLine.h
+++ b/Constraint/NodeLine.h
@@ -39,9 +39,6 @@ class NodeLine final : public Constraint {
 
     bool initial_right{true};
 
-    [[nodiscard]] bool validate_node() const override { return true; }
-    [[nodiscard]] bool collect_node() const override { return true; }
-
 public:
     NodeLine(unsigned, unsigned, uvec&&);
 

--- a/Constraint/ParticleCollision.cpp
+++ b/Constraint/ParticleCollision.cpp
@@ -30,6 +30,7 @@ int ParticleCollision::initialize(const shared_ptr<DomainBase>& D) {
     }
 
     if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
+
     return validate_node_impl(D) ? SUANPAN_SUCCESS : SUANPAN_FAIL;
 }
 

--- a/Constraint/ParticleCollision.cpp
+++ b/Constraint/ParticleCollision.cpp
@@ -31,7 +31,7 @@ int ParticleCollision::initialize(const shared_ptr<DomainBase>& D) {
 
     if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
 
-    return validate_node_impl(D) ? SUANPAN_SUCCESS : SUANPAN_FAIL;
+    return validate_node(D) ? SUANPAN_SUCCESS : SUANPAN_FAIL;
 }
 
 void ParticleCollision::apply_contact(const shared_ptr<DomainBase>& D, const shared_ptr<Node>& node_i, const shared_ptr<Node>& node_j, const bool full) {

--- a/Constraint/ParticleCollision.cpp
+++ b/Constraint/ParticleCollision.cpp
@@ -29,7 +29,8 @@ int ParticleCollision::initialize(const shared_ptr<DomainBase>& D) {
         return SUANPAN_FAIL;
     }
 
-    return Constraint::initialize(D);
+    if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
+    return validate_node_impl(D) ? SUANPAN_SUCCESS : SUANPAN_FAIL;
 }
 
 void ParticleCollision::apply_contact(const shared_ptr<DomainBase>& D, const shared_ptr<Node>& node_i, const shared_ptr<Node>& node_j, const bool full) {

--- a/Constraint/ParticleCollision.h
+++ b/Constraint/ParticleCollision.h
@@ -45,8 +45,6 @@ class ParticleCollision : public Constraint {
      */
     [[nodiscard]] virtual double compute_df(double) const = 0;
 
-    [[nodiscard]] bool validate_node() const final { return true; }
-
 protected:
     const unsigned dimension;
 

--- a/Constraint/RestitutionWallPenalty.cpp
+++ b/Constraint/RestitutionWallPenalty.cpp
@@ -80,7 +80,7 @@ int RestitutionWallPenalty::process(const shared_ptr<DomainBase>& D) {
         counter = next_counter;
     }
 
-    target_node_dof = pool;
+    target_dof = pool;
 
     return SUANPAN_SUCCESS;
 }

--- a/Constraint/RigidWallPenalty.cpp
+++ b/Constraint/RigidWallPenalty.cpp
@@ -37,6 +37,11 @@ RigidWallPenalty::RigidWallPenalty(const unsigned T, const unsigned A, vec&& O, 
     , length_a(norm(edge_a))
     , length_b(norm(edge_b)) {}
 
+int RigidWallPenalty::initialize(const shared_ptr<DomainBase>& D) {
+    if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
+    return validate_node_impl(D) ? SUANPAN_SUCCESS : SUANPAN_FAIL;
+}
+
 int RigidWallPenalty::process(const shared_ptr<DomainBase>& D) {
     auto& W = D->get_factory();
 

--- a/Constraint/RigidWallPenalty.cpp
+++ b/Constraint/RigidWallPenalty.cpp
@@ -40,7 +40,7 @@ RigidWallPenalty::RigidWallPenalty(const unsigned T, const unsigned A, vec&& O, 
 int RigidWallPenalty::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
 
-    return validate_node_impl(D) ? SUANPAN_SUCCESS : SUANPAN_FAIL;
+    return validate_node(D) ? SUANPAN_SUCCESS : SUANPAN_FAIL;
 }
 
 int RigidWallPenalty::process(const shared_ptr<DomainBase>& D) {

--- a/Constraint/RigidWallPenalty.cpp
+++ b/Constraint/RigidWallPenalty.cpp
@@ -39,6 +39,7 @@ RigidWallPenalty::RigidWallPenalty(const unsigned T, const unsigned A, vec&& O, 
 
 int RigidWallPenalty::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
+
     return validate_node_impl(D) ? SUANPAN_SUCCESS : SUANPAN_FAIL;
 }
 

--- a/Constraint/RigidWallPenalty.cpp
+++ b/Constraint/RigidWallPenalty.cpp
@@ -72,7 +72,7 @@ int RigidWallPenalty::process(const shared_ptr<DomainBase>& D) {
         counter = next_counter;
     }
 
-    target_node_dof = pool;
+    target_dof = pool;
 
     return SUANPAN_SUCCESS;
 }

--- a/Constraint/RigidWallPenalty.h
+++ b/Constraint/RigidWallPenalty.h
@@ -40,8 +40,6 @@ class RigidWallPenalty : public Constraint {
         return ref_dof;
     }
 
-    [[nodiscard]] bool validate_node() const override { return true; }
-
 protected:
     const unsigned n_dim;
 
@@ -54,6 +52,8 @@ protected:
 public:
     RigidWallPenalty(unsigned, unsigned, vec&&, vec&&, double, unsigned);
     RigidWallPenalty(unsigned, unsigned, vec&&, vec&&, vec&&, double, unsigned);
+
+    int initialize(const shared_ptr<DomainBase>&) override;
 
     int process(const shared_ptr<DomainBase>&) override;
 

--- a/Domain/ConditionalModifier.cpp
+++ b/Domain/ConditionalModifier.cpp
@@ -115,7 +115,7 @@ std::set<uword> ConditionalModifier::get_involving_nodes(const shared_ptr<Domain
     return pool;
 }
 
-const uvec& ConditionalModifier::get_node_dof() const { return target_node_dof; }
+const uvec& ConditionalModifier::get_node_dof() const { return target_dof; }
 
 void ConditionalModifier::deinitialize() { initialized = false; }
 

--- a/Domain/ConditionalModifier.cpp
+++ b/Domain/ConditionalModifier.cpp
@@ -72,27 +72,6 @@ uvec ConditionalModifier::collect_node_dof(const shared_ptr<DomainBase>& D) cons
     return active_dof;
 }
 
-uvec ConditionalModifier::collect_element_dof(const shared_ptr<DomainBase>& D) const {
-    auto& ref_component = get_dof_component();
-
-    if(ref_component.empty()) return {};
-
-    std::vector<uword> active_dof;
-
-    const auto check = [&](const shared_ptr<Element>& element) {
-        if(!element || !element->is_active()) return;
-        for(const auto tag : element->get_node_encoding())
-            if(auto& node = D->get<Node>(tag); node && node->is_active()) suanpan::append_to(active_dof, node->get_dof(ref_component));
-    };
-
-    if(target_element.is_empty())
-        for(auto& element : D->get_element_pool()) check(element);
-    else
-        for(const auto tag : target_element) check(D->get<Element>(tag));
-
-    return active_dof;
-}
-
 double ConditionalModifier::get_amplitude(const shared_ptr<DomainBase>& D) const { return amplitude->get_amplitude(D->get_factory()->get_trial_time()); }
 
 const std::vector<Node::DOF>& ConditionalModifier::get_dof_component() const { return dof_component.empty() ? dof_order : dof_component; }
@@ -114,12 +93,6 @@ int ConditionalModifier::initialize(const shared_ptr<DomainBase>& D) {
         start_time += t_step->get_time_period();
     }
     amplitude->set_start_time(start_time);
-
-    if(validate_node() && !validate_node_impl(D)) return SUANPAN_FAIL;
-    if(validate_element() && !validate_element_impl(D)) return SUANPAN_FAIL;
-
-    if(collect_node()) target_node_dof = collect_node_dof(D);
-    if(collect_element()) target_element_dof = collect_element_dof(D);
 
     initialized = true;
 

--- a/Domain/ConditionalModifier.cpp
+++ b/Domain/ConditionalModifier.cpp
@@ -22,7 +22,7 @@
 #include <Load/Amplitude/Ramp.h>
 #include <Step/Step.h>
 
-bool ConditionalModifier::validate_node_impl(const shared_ptr<DomainBase>& D) const {
+bool ConditionalModifier::validate_node(const shared_ptr<DomainBase>& D) const {
     const auto not_valid = [&](const shared_ptr<Node>& node) { return !node || !node->is_active() || !node->validate_dof(dof_order); };
 
     if(target_node.is_empty())
@@ -37,7 +37,7 @@ bool ConditionalModifier::validate_node_impl(const shared_ptr<DomainBase>& D) co
     return true;
 }
 
-bool ConditionalModifier::validate_element_impl(const shared_ptr<DomainBase>& D) const {
+bool ConditionalModifier::validate_element(const shared_ptr<DomainBase>& D) const {
     const auto not_valid = [&](const shared_ptr<Element>& element) { return !element || !element->is_active() || !element->validate_dof(dof_order); };
 
     if(target_element.is_empty())

--- a/Domain/ConditionalModifier.cpp
+++ b/Domain/ConditionalModifier.cpp
@@ -22,7 +22,7 @@
 #include <Load/Amplitude/Ramp.h>
 #include <Step/Step.h>
 
-bool ConditionalModifier::validate_node_impl(const shared_ptr<DomainBase>& D) {
+bool ConditionalModifier::validate_node_impl(const shared_ptr<DomainBase>& D) const {
     const auto not_valid = [&](const shared_ptr<Node>& node) { return !node || !node->is_active() || !node->validate_dof(dof_order); };
 
     if(target_node.is_empty())
@@ -37,7 +37,7 @@ bool ConditionalModifier::validate_node_impl(const shared_ptr<DomainBase>& D) {
     return true;
 }
 
-bool ConditionalModifier::validate_element_impl(const shared_ptr<DomainBase>& D) {
+bool ConditionalModifier::validate_element_impl(const shared_ptr<DomainBase>& D) const {
     const auto not_valid = [&](const shared_ptr<Element>& element) { return !element || !element->is_active() || !element->validate_dof(dof_order); };
 
     if(target_element.is_empty())
@@ -52,7 +52,7 @@ bool ConditionalModifier::validate_element_impl(const shared_ptr<DomainBase>& D)
     return true;
 }
 
-uvec ConditionalModifier::collect_node_dof(const shared_ptr<DomainBase>& D) {
+uvec ConditionalModifier::collect_node_dof(const shared_ptr<DomainBase>& D) const {
     auto& ref_component = get_dof_component();
 
     if(ref_component.empty()) return {};
@@ -72,7 +72,7 @@ uvec ConditionalModifier::collect_node_dof(const shared_ptr<DomainBase>& D) {
     return active_dof;
 }
 
-uvec ConditionalModifier::collect_element_dof(const shared_ptr<DomainBase>& D) {
+uvec ConditionalModifier::collect_element_dof(const shared_ptr<DomainBase>& D) const {
     auto& ref_component = get_dof_component();
 
     if(ref_component.empty()) return {};

--- a/Domain/ConditionalModifier.cpp
+++ b/Domain/ConditionalModifier.cpp
@@ -118,8 +118,8 @@ int ConditionalModifier::initialize(const shared_ptr<DomainBase>& D) {
     if(validate_node() && !validate_node_impl(D)) return SUANPAN_FAIL;
     if(validate_element() && !validate_element_impl(D)) return SUANPAN_FAIL;
 
-    target_node_dof = collect_node_dof(D);
-    target_element_dof = collect_element_dof(D);
+    if(collect_node()) target_node_dof = collect_node_dof(D);
+    if(collect_element()) target_element_dof = collect_element_dof(D);
 
     initialized = true;
 

--- a/Domain/ConditionalModifier.h
+++ b/Domain/ConditionalModifier.h
@@ -111,6 +111,25 @@ class ConditionalModifier : public UniqueTag {
     // the modifier itself will apply itself to those active components
     const std::vector<Node::DOF> dof_component;
 
+    /**
+     * \brief Derived classes must indicate if to validate nodes.
+     * Validation will check if the defined nodes have compatible DoF layout.
+     */
+    [[nodiscard]] virtual bool validate_node() const { return false; }
+    /**
+     * \brief Derived classes must indicate if to validate elements.
+     * Validation will check if the defined elements have compatible DoF layout.
+     */
+    [[nodiscard]] virtual bool validate_element() const { return false; }
+    /**
+     * \brief Derived classes must indicate if to collect DoFs from node list.
+     */
+    [[nodiscard]] virtual bool collect_node() const { return false; }
+    /**
+     * \brief Derived classes must indicate if to collect DoFs from element list.
+     */
+    [[nodiscard]] virtual bool collect_element() const { return false; }
+
     bool validate_node_impl(const shared_ptr<DomainBase>&);
     bool validate_element_impl(const shared_ptr<DomainBase>&);
 
@@ -127,17 +146,6 @@ protected:
     const std::vector<Node::DOF> dof_order;
 
     uvec target_node, target_element, target_node_dof, target_element_dof;
-
-    /**
-     * \brief Derived classes must indicate if to validate nodes.
-     * Validation will check if the defined nodes have compatible DoF layout.
-     */
-    [[nodiscard]] virtual bool validate_node() const { return false; }
-    /**
-     * \brief Derived classes must indicate if to validate elements.
-     * Validation will check if the defined elements have compatible DoF layout.
-     */
-    [[nodiscard]] virtual bool validate_element() const { return false; }
 
     [[nodiscard]] double get_amplitude(const shared_ptr<DomainBase>&) const;
 

--- a/Domain/ConditionalModifier.h
+++ b/Domain/ConditionalModifier.h
@@ -131,8 +131,8 @@ protected:
      */
     [[nodiscard]] const std::vector<Node::DOF>& get_dof_component() const;
 
-    [[nodiscard]] bool validate_node_impl(const shared_ptr<DomainBase>&) const;
-    [[nodiscard]] bool validate_element_impl(const shared_ptr<DomainBase>&) const;
+    [[nodiscard]] bool validate_node(const shared_ptr<DomainBase>&) const;
+    [[nodiscard]] bool validate_element(const shared_ptr<DomainBase>&) const;
 
     [[nodiscard]] uvec collect_node_dof(const shared_ptr<DomainBase>&) const;
 

--- a/Domain/ConditionalModifier.h
+++ b/Domain/ConditionalModifier.h
@@ -111,31 +111,6 @@ class ConditionalModifier : public UniqueTag {
     // the modifier itself will apply itself to those active components
     const std::vector<Node::DOF> dof_component;
 
-    /**
-     * \brief Derived classes must indicate if to validate nodes.
-     * Validation will check if the defined nodes have compatible DoF layout.
-     */
-    [[nodiscard]] virtual bool validate_node() const { return false; }
-    /**
-     * \brief Derived classes must indicate if to validate elements.
-     * Validation will check if the defined elements have compatible DoF layout.
-     */
-    [[nodiscard]] virtual bool validate_element() const { return false; }
-    /**
-     * \brief Derived classes must indicate if to collect DoFs from node list.
-     */
-    [[nodiscard]] virtual bool collect_node() const { return false; }
-    /**
-     * \brief Derived classes must indicate if to collect DoFs from element list.
-     */
-    [[nodiscard]] virtual bool collect_element() const { return false; }
-
-    [[nodiscard]] bool validate_node_impl(const shared_ptr<DomainBase>&) const;
-    [[nodiscard]] bool validate_element_impl(const shared_ptr<DomainBase>&) const;
-
-    [[nodiscard]] uvec collect_node_dof(const shared_ptr<DomainBase>&) const;
-    [[nodiscard]] uvec collect_element_dof(const shared_ptr<DomainBase>&) const;
-
 protected:
     unsigned start_step{1u}, end_step{static_cast<unsigned>(-1)};
 
@@ -145,7 +120,7 @@ protected:
     // it can be empty such that the order check is not performed
     const std::vector<Node::DOF> dof_order;
 
-    uvec target_node, target_element, target_node_dof, target_element_dof;
+    uvec target_node, target_element, target_node_dof;
 
     [[nodiscard]] double get_amplitude(const shared_ptr<DomainBase>&) const;
 
@@ -155,6 +130,11 @@ protected:
      * When DoF order is given, DoF components can be omitted.
      */
     [[nodiscard]] const std::vector<Node::DOF>& get_dof_component() const;
+
+    [[nodiscard]] bool validate_node_impl(const shared_ptr<DomainBase>&) const;
+    [[nodiscard]] bool validate_element_impl(const shared_ptr<DomainBase>&) const;
+
+    [[nodiscard]] uvec collect_node_dof(const shared_ptr<DomainBase>&) const;
 
 public:
     ConditionalModifier(

--- a/Domain/ConditionalModifier.h
+++ b/Domain/ConditionalModifier.h
@@ -130,11 +130,11 @@ class ConditionalModifier : public UniqueTag {
      */
     [[nodiscard]] virtual bool collect_element() const { return false; }
 
-    bool validate_node_impl(const shared_ptr<DomainBase>&);
-    bool validate_element_impl(const shared_ptr<DomainBase>&);
+    [[nodiscard]] bool validate_node_impl(const shared_ptr<DomainBase>&) const;
+    [[nodiscard]] bool validate_element_impl(const shared_ptr<DomainBase>&) const;
 
-    uvec collect_node_dof(const shared_ptr<DomainBase>&);
-    uvec collect_element_dof(const shared_ptr<DomainBase>&);
+    [[nodiscard]] uvec collect_node_dof(const shared_ptr<DomainBase>&) const;
+    [[nodiscard]] uvec collect_element_dof(const shared_ptr<DomainBase>&) const;
 
 protected:
     unsigned start_step{1u}, end_step{static_cast<unsigned>(-1)};

--- a/Domain/ConditionalModifier.h
+++ b/Domain/ConditionalModifier.h
@@ -120,7 +120,7 @@ protected:
     // it can be empty such that the order check is not performed
     const std::vector<Node::DOF> dof_order;
 
-    uvec target_node, target_element, target_node_dof;
+    uvec target_node, target_element, target_dof;
 
     [[nodiscard]] double get_amplitude(const shared_ptr<DomainBase>&) const;
 

--- a/Load/LineUDL.cpp
+++ b/Load/LineUDL.cpp
@@ -26,7 +26,7 @@ LineUDL::LineUDL(const unsigned T, const double L, uvec&& N, std::vector<Node::D
 int LineUDL::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Load::initialize(D)) return SUANPAN_FAIL;
 
-    if(!validate_node_impl(D)) return SUANPAN_FAIL;
+    if(!validate_node(D)) return SUANPAN_FAIL;
 
     target_node_dof = collect_node_dof(D);
 

--- a/Load/LineUDL.cpp
+++ b/Load/LineUDL.cpp
@@ -23,6 +23,16 @@ LineUDL::LineUDL(const unsigned T, const double L, uvec&& N, std::vector<Node::D
     : Load(T, AT, suanpan::translational(D), std::move(DT), L)
     , dimension(D) { target_node = std::move(N); }
 
+int LineUDL::initialize(const shared_ptr<DomainBase>& D) {
+    if(SUANPAN_SUCCESS != Load::initialize(D)) return SUANPAN_FAIL;
+
+    if(!validate_node_impl(D)) return SUANPAN_FAIL;
+
+    target_node_dof = collect_node_dof(D);
+
+    return SUANPAN_SUCCESS;
+}
+
 int LineUDL::process(const shared_ptr<DomainBase>& D) {
     if(target_node_dof.is_empty()) return SUANPAN_SUCCESS;
 

--- a/Load/LineUDL.cpp
+++ b/Load/LineUDL.cpp
@@ -28,17 +28,17 @@ int LineUDL::initialize(const shared_ptr<DomainBase>& D) {
 
     if(!validate_node(D)) return SUANPAN_FAIL;
 
-    target_node_dof = collect_node_dof(D);
+    target_dof = collect_node_dof(D);
 
     return SUANPAN_SUCCESS;
 }
 
 int LineUDL::process(const shared_ptr<DomainBase>& D) {
-    if(target_node_dof.is_empty()) return SUANPAN_SUCCESS;
+    if(target_dof.is_empty()) return SUANPAN_SUCCESS;
 
     trial_load.zeros(D->get_factory()->get_size());
 
-    D->insert_loaded_dof(target_node_dof);
+    D->insert_loaded_dof(target_dof);
 
     mat distribution(dimension, target_node.n_elem, fill::zeros);
     for(auto I = 0llu, J = 1llu; J < target_node.n_elem; ++I, ++J) {
@@ -48,9 +48,9 @@ int LineUDL::process(const shared_ptr<DomainBase>& D) {
     }
 
     const auto ref_load = .5 * magnitude * get_amplitude(D);
-    if(const auto tag = get_dof_component()[0]; Node::DOF::U1 == tag) trial_load(target_node_dof) = ref_load * distribution.row(0).t();
-    else if(Node::DOF::U2 == tag) trial_load(target_node_dof) = ref_load * distribution.row(1).t();
-    else if(Node::DOF::U3 == tag && 3u == dimension) trial_load(target_node_dof) = ref_load * distribution.row(2).t();
+    if(const auto tag = get_dof_component()[0]; Node::DOF::U1 == tag) trial_load(target_dof) = ref_load * distribution.row(0).t();
+    else if(Node::DOF::U2 == tag) trial_load(target_dof) = ref_load * distribution.row(1).t();
+    else if(Node::DOF::U3 == tag && 3u == dimension) trial_load(target_dof) = ref_load * distribution.row(2).t();
 
     return SUANPAN_SUCCESS;
 }

--- a/Load/LineUDL.h
+++ b/Load/LineUDL.h
@@ -48,6 +48,7 @@ public:
         unsigned,                 // amplitude tag
         unsigned                  // dimension
     );
+
     int initialize(const shared_ptr<DomainBase>&) override;
 
     int process(const shared_ptr<DomainBase>&) override;

--- a/Load/LineUDL.h
+++ b/Load/LineUDL.h
@@ -35,6 +35,7 @@
 
 class LineUDL : public Load {
     [[nodiscard]] bool validate_node() const final { return true; }
+    [[nodiscard]] bool collect_node() const final { return true; }
 
 protected:
     const unsigned dimension;

--- a/Load/LineUDL.h
+++ b/Load/LineUDL.h
@@ -34,9 +34,6 @@
 #include "Load.h"
 
 class LineUDL : public Load {
-    [[nodiscard]] bool validate_node() const final { return true; }
-    [[nodiscard]] bool collect_node() const final { return true; }
-
 protected:
     const unsigned dimension;
 
@@ -51,6 +48,7 @@ public:
         unsigned,                 // amplitude tag
         unsigned                  // dimension
     );
+    int initialize(const shared_ptr<DomainBase>&) override;
 
     int process(const shared_ptr<DomainBase>&) override;
 };

--- a/Load/NodalAcceleration.cpp
+++ b/Load/NodalAcceleration.cpp
@@ -22,6 +22,13 @@
 NodalAcceleration::NodalAcceleration(const unsigned T, const double L, uvec&& NT, std::vector<Node::DOF>&& DT, const unsigned AT)
     : Load(T, AT, {}, std::move(DT), L) { target_node = std::move(NT); }
 
+int NodalAcceleration::initialize(const shared_ptr<DomainBase>& D) {
+    if(SUANPAN_SUCCESS != Load::initialize(D)) return SUANPAN_FAIL;
+
+    target_node_dof = collect_node_dof(D);
+    return SUANPAN_SUCCESS;
+}
+
 int NodalAcceleration::process(const shared_ptr<DomainBase>& D) {
     auto& W = D->get_factory();
 

--- a/Load/NodalAcceleration.cpp
+++ b/Load/NodalAcceleration.cpp
@@ -25,7 +25,7 @@ NodalAcceleration::NodalAcceleration(const unsigned T, const double L, uvec&& NT
 int NodalAcceleration::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Load::initialize(D)) return SUANPAN_FAIL;
 
-    target_node_dof = collect_node_dof(D);
+    target_dof = collect_node_dof(D);
 
     return SUANPAN_SUCCESS;
 }
@@ -33,8 +33,8 @@ int NodalAcceleration::initialize(const shared_ptr<DomainBase>& D) {
 int NodalAcceleration::process(const shared_ptr<DomainBase>& D) {
     auto& W = D->get_factory();
 
-    if(auto& t_mass = W->get_mass(); t_mass && !target_node_dof.is_empty()) {
-        trial_load.zeros(W->get_size())(target_node_dof).fill(magnitude * get_amplitude(D));
+    if(auto& t_mass = W->get_mass(); t_mass && !target_dof.is_empty()) {
+        trial_load.zeros(W->get_size())(target_dof).fill(magnitude * get_amplitude(D));
         trial_load = t_mass * trial_load;
     }
     else trial_load.reset();

--- a/Load/NodalAcceleration.cpp
+++ b/Load/NodalAcceleration.cpp
@@ -26,6 +26,7 @@ int NodalAcceleration::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Load::initialize(D)) return SUANPAN_FAIL;
 
     target_node_dof = collect_node_dof(D);
+
     return SUANPAN_SUCCESS;
 }
 

--- a/Load/NodalAcceleration.h
+++ b/Load/NodalAcceleration.h
@@ -34,6 +34,8 @@
 #include "Load.h"
 
 class NodalAcceleration final : public Load {
+    [[nodiscard]] bool collect_node() const override { return true; }
+
 public:
     NodalAcceleration(
         unsigned,                 // tag

--- a/Load/NodalAcceleration.h
+++ b/Load/NodalAcceleration.h
@@ -34,8 +34,6 @@
 #include "Load.h"
 
 class NodalAcceleration final : public Load {
-    [[nodiscard]] bool collect_node() const override { return true; }
-
 public:
     NodalAcceleration(
         unsigned,                 // tag
@@ -44,6 +42,8 @@ public:
         std::vector<Node::DOF>&&, // dof tags
         unsigned                  // amplitude tag
     );
+
+    int initialize(const shared_ptr<DomainBase>&) override;
 
     int process(const shared_ptr<DomainBase>&) override;
 };

--- a/Load/NodalDisplacement.cpp
+++ b/Load/NodalDisplacement.cpp
@@ -25,10 +25,9 @@ NodalDisplacement::NodalDisplacement(const unsigned T, const double L, uvec&& N,
 int NodalDisplacement::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Load::initialize(D)) return SUANPAN_FAIL;
 
-    target_node_dof = collect_node_dof(D);
     set_end_step(start_step + 1);
 
-    D->get_factory()->update_reference_dof(target_node_dof);
+    D->get_factory()->update_reference_dof(target_node_dof = collect_node_dof(D));
 
     return SUANPAN_SUCCESS;
 }

--- a/Load/NodalDisplacement.cpp
+++ b/Load/NodalDisplacement.cpp
@@ -25,6 +25,7 @@ NodalDisplacement::NodalDisplacement(const unsigned T, const double L, uvec&& N,
 int NodalDisplacement::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Load::initialize(D)) return SUANPAN_FAIL;
 
+    target_node_dof = collect_node_dof(D);
     set_end_step(start_step + 1);
 
     D->get_factory()->update_reference_dof(target_node_dof);

--- a/Load/NodalDisplacement.cpp
+++ b/Load/NodalDisplacement.cpp
@@ -27,14 +27,14 @@ int NodalDisplacement::initialize(const shared_ptr<DomainBase>& D) {
 
     set_end_step(start_step + 1);
 
-    D->get_factory()->update_reference_dof(target_node_dof = collect_node_dof(D));
+    D->get_factory()->update_reference_dof(target_dof = collect_node_dof(D));
 
     return SUANPAN_SUCCESS;
 }
 
 int NodalDisplacement::process(const shared_ptr<DomainBase>& D) {
-    if(target_node_dof.empty()) trial_settlement.reset();
-    else trial_settlement.zeros(D->get_factory()->get_size())(target_node_dof).fill(magnitude * get_amplitude(D));
+    if(target_dof.empty()) trial_settlement.reset();
+    else trial_settlement.zeros(D->get_factory()->get_size())(target_dof).fill(magnitude * get_amplitude(D));
 
     return SUANPAN_SUCCESS;
 }

--- a/Load/NodalDisplacement.h
+++ b/Load/NodalDisplacement.h
@@ -34,8 +34,6 @@
 #include "Load.h"
 
 class NodalDisplacement : public Load {
-    [[nodiscard]] bool collect_node() const final { return true; }
-
 public:
     NodalDisplacement(
         unsigned,                 // tag

--- a/Load/NodalDisplacement.h
+++ b/Load/NodalDisplacement.h
@@ -34,6 +34,8 @@
 #include "Load.h"
 
 class NodalDisplacement : public Load {
+    [[nodiscard]] bool collect_node() const final { return true; }
+
 public:
     NodalDisplacement(
         unsigned,                 // tag

--- a/Load/NodalForce.cpp
+++ b/Load/NodalForce.cpp
@@ -25,16 +25,16 @@ NodalForce::NodalForce(const unsigned T, const double L, uvec&& N, std::vector<N
 int NodalForce::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Load::initialize(D)) return SUANPAN_FAIL;
 
-    target_node_dof = collect_node_dof(D);
+    target_dof = collect_node_dof(D);
 
     return SUANPAN_SUCCESS;
 }
 
 int NodalForce::process(const shared_ptr<DomainBase>& D) {
-    D->insert_loaded_dof(target_node_dof);
+    D->insert_loaded_dof(target_dof);
 
-    if(target_node_dof.is_empty()) trial_load.reset();
-    else trial_load.zeros(D->get_factory()->get_size())(target_node_dof).fill(magnitude * get_amplitude(D));
+    if(target_dof.is_empty()) trial_load.reset();
+    else trial_load.zeros(D->get_factory()->get_size())(target_dof).fill(magnitude * get_amplitude(D));
 
     return SUANPAN_SUCCESS;
 }

--- a/Load/NodalForce.cpp
+++ b/Load/NodalForce.cpp
@@ -22,6 +22,14 @@
 NodalForce::NodalForce(const unsigned T, const double L, uvec&& N, std::vector<Node::DOF>&& D, const unsigned AT)
     : Load(T, AT, {}, std::move(D), L) { target_node = std::move(N); }
 
+int NodalForce::initialize(const shared_ptr<DomainBase>& D) {
+    if(SUANPAN_SUCCESS != Load::initialize(D)) return SUANPAN_FAIL;
+
+    target_node_dof = collect_node_dof(D);
+
+    return SUANPAN_SUCCESS;
+}
+
 int NodalForce::process(const shared_ptr<DomainBase>& D) {
     D->insert_loaded_dof(target_node_dof);
 

--- a/Load/NodalForce.h
+++ b/Load/NodalForce.h
@@ -34,8 +34,6 @@
 #include "Load.h"
 
 class NodalForce : public Load {
-    [[nodiscard]] bool collect_node() const final { return true; }
-
 public:
     NodalForce(
         unsigned,                 // tag
@@ -44,6 +42,8 @@ public:
         std::vector<Node::DOF>&&, // dof tags
         unsigned                  // amplitude tag
     );
+
+    int initialize(const shared_ptr<DomainBase>&) override;
 
     int process(const shared_ptr<DomainBase>&) override;
 };

--- a/Load/NodalForce.h
+++ b/Load/NodalForce.h
@@ -34,6 +34,8 @@
 #include "Load.h"
 
 class NodalForce : public Load {
+    [[nodiscard]] bool collect_node() const final { return true; }
+
 public:
     NodalForce(
         unsigned,                 // tag

--- a/Load/ReferenceForce.cpp
+++ b/Load/ReferenceForce.cpp
@@ -25,7 +25,7 @@ ReferenceForce::ReferenceForce(const unsigned T, const double L, uvec&& N, std::
 int ReferenceForce::initialize(const shared_ptr<DomainBase>& D) {
     if(SUANPAN_SUCCESS != Load::initialize(D)) return SUANPAN_FAIL;
 
-    target_node_dof = collect_node_dof(D);
+    target_dof = collect_node_dof(D);
 
     return SUANPAN_SUCCESS;
 }
@@ -33,7 +33,7 @@ int ReferenceForce::initialize(const shared_ptr<DomainBase>& D) {
 int ReferenceForce::process(const shared_ptr<DomainBase>& D) {
     reference_load.zeros(D->get_factory()->get_size());
 
-    for(const auto I : target_node_dof) reference_load(I) = magnitude;
+    for(const auto I : target_dof) reference_load(I) = magnitude;
 
     return SUANPAN_SUCCESS;
 }

--- a/Load/ReferenceForce.cpp
+++ b/Load/ReferenceForce.cpp
@@ -22,6 +22,14 @@
 ReferenceForce::ReferenceForce(const unsigned T, const double L, uvec&& N, std::vector<Node::DOF>&& D)
     : Load(T, 0, {}, std::move(D), L) { target_node = std::move(N); }
 
+int ReferenceForce::initialize(const shared_ptr<DomainBase>& D) {
+    if(SUANPAN_SUCCESS != Load::initialize(D)) return SUANPAN_FAIL;
+
+    target_node_dof = collect_node_dof(D);
+
+    return SUANPAN_SUCCESS;
+}
+
 int ReferenceForce::process(const shared_ptr<DomainBase>& D) {
     reference_load.zeros(D->get_factory()->get_size());
 

--- a/Load/ReferenceForce.h
+++ b/Load/ReferenceForce.h
@@ -34,6 +34,8 @@
 #include "Load.h"
 
 class ReferenceForce final : public Load {
+    [[nodiscard]] bool collect_node() const override { return true; }
+
 public:
     ReferenceForce(
         unsigned,                // tag

--- a/Load/ReferenceForce.h
+++ b/Load/ReferenceForce.h
@@ -34,8 +34,6 @@
 #include "Load.h"
 
 class ReferenceForce final : public Load {
-    [[nodiscard]] bool collect_node() const override { return true; }
-
 public:
     ReferenceForce(
         unsigned,                // tag
@@ -43,6 +41,8 @@ public:
         uvec&&,                  // node tags
         std::vector<Node::DOF>&& // dof tag
     );
+
+    int initialize(const shared_ptr<DomainBase>&) override;
 
     int process(const shared_ptr<DomainBase>&) override;
 };

--- a/Load/SupportMotion.cpp
+++ b/Load/SupportMotion.cpp
@@ -29,14 +29,14 @@ int SupportMotion::initialize(const shared_ptr<DomainBase>& D) {
 
     set_end_step(start_step + 1);
 
-    D->get_factory()->update_reference_dof(target_node_dof = collect_node_dof(D));
+    D->get_factory()->update_reference_dof(target_dof = collect_node_dof(D));
 
     return SUANPAN_SUCCESS;
 }
 
 int SupportDisplacement::process(const shared_ptr<DomainBase>& D) {
-    if(target_node_dof.is_empty()) trial_settlement.reset();
-    else trial_settlement.zeros(D->get_factory()->get_size())(target_node_dof).fill(magnitude * get_amplitude(D));
+    if(target_dof.is_empty()) trial_settlement.reset();
+    else trial_settlement.zeros(D->get_factory()->get_size())(target_dof).fill(magnitude * get_amplitude(D));
 
     return SUANPAN_SUCCESS;
 }
@@ -45,8 +45,8 @@ int SupportVelocity::process(const shared_ptr<DomainBase>& D) {
     const auto& W = D->get_factory();
     const auto& G = D->get_current_step()->get_integrator();
 
-    if(target_node_dof.is_empty()) trial_settlement.reset();
-    else trial_settlement.zeros(W->get_size())(target_node_dof) = G->from_total_velocity(magnitude * get_amplitude(D), target_node_dof);
+    if(target_dof.is_empty()) trial_settlement.reset();
+    else trial_settlement.zeros(W->get_size())(target_dof) = G->from_total_velocity(magnitude * get_amplitude(D), target_dof);
 
     return SUANPAN_SUCCESS;
 }
@@ -55,8 +55,8 @@ int SupportAcceleration::process(const shared_ptr<DomainBase>& D) {
     const auto& W = D->get_factory();
     const auto& G = D->get_current_step()->get_integrator();
 
-    if(target_node_dof.is_empty()) trial_settlement.reset();
-    else trial_settlement.zeros(W->get_size())(target_node_dof) = G->from_total_acceleration(magnitude * get_amplitude(D), target_node_dof);
+    if(target_dof.is_empty()) trial_settlement.reset();
+    else trial_settlement.zeros(W->get_size())(target_dof) = G->from_total_acceleration(magnitude * get_amplitude(D), target_dof);
 
     return SUANPAN_SUCCESS;
 }

--- a/Load/SupportMotion.cpp
+++ b/Load/SupportMotion.cpp
@@ -29,7 +29,7 @@ int SupportMotion::initialize(const shared_ptr<DomainBase>& D) {
 
     set_end_step(start_step + 1);
 
-    D->get_factory()->update_reference_dof(target_node_dof);
+    D->get_factory()->update_reference_dof(target_node_dof = collect_node_dof(D));
 
     return SUANPAN_SUCCESS;
 }

--- a/Load/SupportMotion.h
+++ b/Load/SupportMotion.h
@@ -34,6 +34,8 @@
 #include "Load.h"
 
 class SupportMotion : public Load {
+    [[nodiscard]] bool collect_node() const final { return true; }
+
 public:
     SupportMotion(
         unsigned,                 // tag

--- a/Load/SupportMotion.h
+++ b/Load/SupportMotion.h
@@ -34,8 +34,6 @@
 #include "Load.h"
 
 class SupportMotion : public Load {
-    [[nodiscard]] bool collect_node() const final { return true; }
-
 public:
     SupportMotion(
         unsigned,                 // tag


### PR DESCRIPTION
Refactor the ConditionalModifier to conditionally collect degrees of freedom (DoFs) and introduce virtual methods for validation and collection. Add a `collect_node` method to various Load and Constraint classes to standardize node collection behavior.