### PR TITLE
Add parallel execution support for transform_reduce and update max_element policy

### DIFF
--- a/Constraint/MolecularDynamics.h
+++ b/Constraint/MolecularDynamics.h
@@ -79,7 +79,12 @@ public:
         for(auto&& item : D->get_element_pool())
             if(item && item->is_active() && item->type() == Element::Type::DEM) elements.emplace_back(item);
 
-        space = 2. * std::transform_reduce(elements.cbegin(), elements.cend(), 0., [](const double a, const double b) { return std::max(a, b); }, [](const std::shared_ptr<Element>& element) { return element->get(Element::Parameter::RADIUS); });
+        space = 2. * std::transform_reduce(
+#ifdef SUANPAN_MT
+                         std::execution::par_unseq,
+#endif
+                         elements.cbegin(), elements.cend(), 0., [](const double a, const double b) { return std::max(a, b); }, [](const std::shared_ptr<Element>& element) { return element->get(Element::Parameter::RADIUS); }
+                     );
 
         if(SUANPAN_SUCCESS != Constraint::initialize(D)) return SUANPAN_FAIL;
 

--- a/Domain/Domain.cpp
+++ b/Domain/Domain.cpp
@@ -933,7 +933,12 @@ int Domain::assign_color() {
     // count how many entries in the sparse form and preallocate memory
     if(is_sparse()) {
         auto& t_element_pool = element_pond.get();
-        factory->set_entry(std::transform_reduce(t_element_pool.cbegin(), t_element_pool.cend(), uword{1000}, std::plus(), [](const shared_ptr<Element>& t_element) { return t_element->get_total_number() * t_element->get_total_number(); }));
+        factory->set_entry(std::transform_reduce(
+#ifdef SUANPAN_MT
+            std::execution::par_unseq,
+#endif
+            t_element_pool.cbegin(), t_element_pool.cend(), uword{1000}, std::plus(), [](const shared_ptr<Element>& t_element) { return t_element->get_total_number() * t_element->get_total_number(); }
+        ));
     }
 
     return SUANPAN_SUCCESS;

--- a/Toolbox/utility.h
+++ b/Toolbox/utility.h
@@ -42,7 +42,7 @@ namespace suanpan {
     template<typename T> constexpr T max_element(T start, T end) {
         return std::max_element(
 #ifdef __cpp_lib_execution
-            std::execution::par,
+            std::execution::par_unseq,
 #endif
             start, end
         );


### PR DESCRIPTION
Introduce parallel execution capabilities for `transform_reduce` in both `MolecularDynamics` and `Domain`. Update the `max_element` function to utilize the `par_unseq` execution policy for improved performance.