### PR TITLE
Enable parallel build support in CMake for macOS

### DIFF
--- a/.github/workflows/dev-all.yml
+++ b/.github/workflows/dev-all.yml
@@ -351,9 +351,6 @@ jobs:
         compiler:
           - gcc
           - clang
-        exclude:
-          - compiler: gcc
-            vtk: 'ON'
         os:
           - macos-15-large
           - macos-15-xlarge

--- a/.github/workflows/dev-all.yml
+++ b/.github/workflows/dev-all.yml
@@ -351,6 +351,9 @@ jobs:
         compiler:
           - gcc
           - clang
+        exclude:
+          - compiler: gcc
+            vtk: 'ON'
         os:
           - macos-15-large
           - macos-15-xlarge

--- a/.github/workflows/dev-all.yml
+++ b/.github/workflows/dev-all.yml
@@ -332,10 +332,7 @@ jobs:
           ln -s /Applications "$staging/Applications"
           hdiutil create -volname "suanPan" -srcfolder "$staging" -ov -format UDZO "build/${{ env.ARTIFACT }}.dmg"
       - name: Test
-        run: ./build/dist/bin/suanPan -v
-      - name: Debug
-        if: failure()
-        uses: mxschmitt/action-tmate@v3
+        run: ./build/dist/suanPan.sh -v
       - name: Upload
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/dev-all.yml
+++ b/.github/workflows/dev-all.yml
@@ -289,19 +289,24 @@ jobs:
             fi
             cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
+            -DCMAKE_C_STANDARD_INCLUDE_DIRECTORIES=$(brew --prefix libomp)/include \
+            -DCMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES=$(brew --prefix libomp)/include \
+            -DCMAKE_Fortran_STANDARD_INCLUDE_DIRECTORIES=$(brew --prefix libomp)/include \
             -DCMAKE_PREFIX_PATH="$(brew --prefix libomp);$(brew --prefix gcc@15)" \
             -DCMAKE_INSTALL_PREFIX=build/dist \
-            -DSP_BUILD_PARALLEL=OFF \
+            -DSP_BUILD_PARALLEL=ON \
             -DSP_ENABLE_VTK=${{ matrix.vtk }} \
             -DVTK_PATH=/Users/runner/work/suanPan/suanPan/VTK/lib/cmake/vtk-9.6/
           else
-            export CC=gcc-15
-            export CXX=g++-15
+            export CC=gcc-15 && export CXX=g++-15
             cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
-            -DCMAKE_PREFIX_PATH="$(brew --prefix gcc@15)" \
+            -DCMAKE_C_STANDARD_INCLUDE_DIRECTORIES=$(brew --prefix libomp)/include \
+            -DCMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES=$(brew --prefix libomp)/include \
+            -DCMAKE_Fortran_STANDARD_INCLUDE_DIRECTORIES=$(brew --prefix libomp)/include \
+            -DCMAKE_PREFIX_PATH="$(brew --prefix libomp);$(brew --prefix gcc@15)" \
             -DCMAKE_INSTALL_PREFIX=build/dist \
-            -DSP_BUILD_PARALLEL=OFF \
+            -DSP_BUILD_PARALLEL=ON \
             -DSP_ENABLE_VTK=${{ matrix.vtk }} \
             -DVTK_PATH=/Users/runner/work/suanPan/suanPan/VTK/lib/cmake/vtk-9.6/
           fi

--- a/.github/workflows/dev-all.yml
+++ b/.github/workflows/dev-all.yml
@@ -333,6 +333,9 @@ jobs:
           hdiutil create -volname "suanPan" -srcfolder "$staging" -ov -format UDZO "build/${{ env.ARTIFACT }}.dmg"
       - name: Test
         run: ./build/dist/bin/suanPan -v
+      - name: Debug
+        if: failure()
+        uses: mxschmitt/action-tmate@v3
       - name: Upload
         uses: actions/upload-artifact@v7
         with:

--- a/Script/mac-dependency.sh
+++ b/Script/mac-dependency.sh
@@ -82,6 +82,7 @@ TMP_DIR="$(mktemp -d)"
 wget -q -O "$TMP_DIR/archive.tar.gz" "$TARBALL_URL"
 tar -xzf "$TMP_DIR/archive.tar.gz" -C "$TMP_DIR"
 
+rm -rf "$TARGET_DIR/libopenblas*"
 find "$TMP_DIR" -name "*.dylib" -exec cp -P {} "$TARGET_DIR" \;
 # cp "$TMP_DIR/libopenblas.a" "$TARGET_DIR"
 

--- a/Script/mac-dependency.sh
+++ b/Script/mac-dependency.sh
@@ -69,6 +69,7 @@ TMP_DIR="$(mktemp -d)"
 wget -q -O "$TMP_DIR/archive.tar.gz" "$TARBALL_URL"
 tar -xzf "$TMP_DIR/archive.tar.gz" -C "$TMP_DIR"
 
+rm -rf "$TARGET_DIR/libtbb*"
 find "$TMP_DIR/tbb-install/lib" -name "*.dylib" -exec cp -P {} "$TARGET_DIR" \;
 rm -rf "$(dirname "$0")/../Include/tbb/*"
 cp -a "$TMP_DIR/tbb-install/include/." "$(dirname "$0")/../Include/tbb"

--- a/Script/mac-dependency.sh
+++ b/Script/mac-dependency.sh
@@ -63,13 +63,15 @@ find "$TMP_DIR/lib" -name "*.a" -exec cp {} "$TARGET_DIR" \;
 
 rm -rf "$TMP_DIR"
 
-TARBALL_URL="https://github.com/TLCFEM/prebuilds/releases/download/latest/tbb-$RUNNER_IMAGE_NAME.tar.gz"
+TARBALL_URL="https://github.com/TLCFEM/prebuilds/releases/download/latest/tbb-v2023.1.0-$RUNNER_IMAGE_NAME.tar.gz"
 TMP_DIR="$(mktemp -d)"
 
 wget -q -O "$TMP_DIR/archive.tar.gz" "$TARBALL_URL"
 tar -xzf "$TMP_DIR/archive.tar.gz" -C "$TMP_DIR"
 
 find "$TMP_DIR/tbb-install/lib" -name "*.dylib" -exec cp -P {} "$TARGET_DIR" \;
+rm -rf "$(dirname "$0")/../Include/tbb/*"
+cp -a "$TMP_DIR/tbb-install/include/." "$(dirname "$0")/../Include/tbb"
 
 rm -rf "$TMP_DIR"
 

--- a/Script/mac-dependency.sh
+++ b/Script/mac-dependency.sh
@@ -70,8 +70,8 @@ wget -q -O "$TMP_DIR/archive.tar.gz" "$TARBALL_URL"
 tar -xzf "$TMP_DIR/archive.tar.gz" -C "$TMP_DIR"
 
 rm -rf "$TARGET_DIR/libtbb*"
-find "$TMP_DIR/tbb-install/lib" -name "*.dylib" -exec cp -P {} "$TARGET_DIR" \;
 rm -rf "$(dirname "$0")/../Include/tbb/*"
+find "$TMP_DIR/tbb-install/lib" -name "*.dylib" -exec cp -P {} "$TARGET_DIR" \;
 cp -a "$TMP_DIR/tbb-install/include/." "$(dirname "$0")/../Include/tbb"
 
 rm -rf "$TMP_DIR"


### PR DESCRIPTION
Enable parallel build support in the CMake configuration for macOS to improve build efficiency. This change modifies the build settings to allow parallel processing during the build process.