### PR TITLE
Enhance macOS build configuration for parallel builds

### DIFF
--- a/.github/workflows/dev-all.yml
+++ b/.github/workflows/dev-all.yml
@@ -289,8 +289,12 @@ jobs:
             fi
             cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
+            -DCMAKE_C_STANDARD_INCLUDE_DIRECTORIES=$(brew --prefix libomp)/include \
+            -DCMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES=$(brew --prefix libomp)/include \
+            -DCMAKE_Fortran_STANDARD_INCLUDE_DIRECTORIES=$(brew --prefix libomp)/include \
             -DCMAKE_PREFIX_PATH="$(brew --prefix libomp);$(brew --prefix gcc@13)" \
             -DCMAKE_INSTALL_PREFIX=build/dist \
+            -DSP_BUILD_PARALLEL=ON \
             -DSP_ENABLE_VTK=${{ matrix.vtk }} \
             -DVTK_PATH=/Users/runner/work/suanPan/suanPan/VTK/lib/cmake/vtk-9.6/
           else
@@ -298,8 +302,12 @@ jobs:
             export CXX=g++-13
             cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
-            -DCMAKE_PREFIX_PATH="$(brew --prefix gcc@13)" \
+            -DCMAKE_C_STANDARD_INCLUDE_DIRECTORIES=$(brew --prefix libomp)/include \
+            -DCMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES=$(brew --prefix libomp)/include \
+            -DCMAKE_Fortran_STANDARD_INCLUDE_DIRECTORIES=$(brew --prefix libomp)/include \
+            -DCMAKE_PREFIX_PATH="$(brew --prefix libomp);$(brew --prefix gcc@13)" \
             -DCMAKE_INSTALL_PREFIX=build/dist \
+            -DSP_BUILD_PARALLEL=ON \
             -DSP_ENABLE_VTK=${{ matrix.vtk }} \
             -DVTK_PATH=/Users/runner/work/suanPan/suanPan/VTK/lib/cmake/vtk-9.6/
           fi


### PR DESCRIPTION
Add libomp include directories and enable parallel builds in the macOS configuration to improve build performance.