### PR TITLE
Refactor criterion handling and remove step tag

### DIFF
--- a/Constraint/ConstraintParser.cpp
+++ b/Constraint/ConstraintParser.cpp
@@ -412,12 +412,6 @@ namespace {
 } // namespace
 
 int create_new_criterion(const shared_ptr<DomainBase>& domain, std::istringstream& command) {
-    const auto step_tag = domain->get_current_step_tag();
-    if(0u == step_tag) {
-        suanpan_error("A valid step is required.\n");
-        return SUANPAN_SUCCESS;
-    }
-
     std::string criterion_type;
     if(!get_input(command, criterion_type)) {
         suanpan_error("A valid criterion type is required.\n");
@@ -430,7 +424,7 @@ int create_new_criterion(const shared_ptr<DomainBase>& domain, std::istringstrea
         return SUANPAN_SUCCESS;
     }
 
-    auto flag = true;
+    unique_ptr<Criterion> new_criterion = nullptr;
 
     if(is_equal(criterion_type.substr(0, 5), "Logic")) {
         unsigned tag_a, tag_b;
@@ -439,8 +433,8 @@ int create_new_criterion(const shared_ptr<DomainBase>& domain, std::istringstrea
             return SUANPAN_SUCCESS;
         }
 
-        if(is_equal(criterion_type, "LogicCriterionAND")) flag = domain->insert(std::make_shared<LogicCriterionAND>(tag, step_tag, tag_a, tag_b));
-        else if(is_equal(criterion_type, "LogicCriterionOR")) flag = domain->insert(std::make_shared<LogicCriterionOR>(tag, step_tag, tag_a, tag_b));
+        if(is_equal(criterion_type, "LogicCriterionAND")) new_criterion = std::make_unique<LogicCriterionAND>(tag, tag_a, tag_b);
+        else if(is_equal(criterion_type, "LogicCriterionOR")) new_criterion = std::make_unique<LogicCriterionOR>(tag, tag_a, tag_b);
     }
     else if(is_equal(criterion_type, "StrainEnergyEvolution")) {
         unsigned incre_level, final_level;
@@ -475,7 +469,7 @@ int create_new_criterion(const shared_ptr<DomainBase>& domain, std::istringstrea
             return SUANPAN_SUCCESS;
         }
 
-        flag = domain->insert(std::make_shared<StrainEnergyEvolution>(tag, step_tag, incre_level, final_level, weight, iteration, reactivation, propagation, tolerance));
+        new_criterion = std::make_unique<StrainEnergyEvolution>(tag, incre_level, final_level, weight, iteration, reactivation, propagation, tolerance);
     }
     else if(is_equal(criterion_type, "MaxHistory")) {
         std::string type;
@@ -489,7 +483,7 @@ int create_new_criterion(const shared_ptr<DomainBase>& domain, std::istringstrea
             return SUANPAN_SUCCESS;
         }
 
-        flag = domain->insert(std::make_shared<MaxHistory>(tag, step_tag, to_token(type), limit, get_remaining<uword>(command)));
+        new_criterion = std::make_unique<MaxHistory>(tag, to_token(type), limit, get_remaining<uword>(command));
     }
     else if(is_equal(criterion_type, "MinHistory")) {
         std::string type;
@@ -503,7 +497,7 @@ int create_new_criterion(const shared_ptr<DomainBase>& domain, std::istringstrea
             return SUANPAN_SUCCESS;
         }
 
-        flag = domain->insert(std::make_shared<MinHistory>(tag, step_tag, to_token(type), limit, get_remaining<uword>(command)));
+        new_criterion = std::make_unique<MinHistory>(tag, to_token(type), limit, get_remaining<uword>(command));
     }
     else {
         unsigned node;
@@ -530,13 +524,15 @@ int create_new_criterion(const shared_ptr<DomainBase>& domain, std::istringstrea
             return SUANPAN_SUCCESS;
         }
 
-        if(is_equal(criterion_type, "MaxDisplacement")) flag = domain->insert(std::make_shared<MaxDisplacement>(tag, step_tag, node, dof_pool[0], limit));
-        else if(is_equal(criterion_type, "MinDisplacement")) flag = domain->insert(std::make_shared<MinDisplacement>(tag, step_tag, node, dof_pool[0], limit));
-        else if(is_equal(criterion_type, "MaxResistance")) flag = domain->insert(std::make_shared<MaxResistance>(tag, step_tag, node, dof_pool[0], limit));
-        else if(is_equal(criterion_type, "MinResistance")) flag = domain->insert(std::make_shared<MinResistance>(tag, step_tag, node, dof_pool[0], limit));
+        if(is_equal(criterion_type, "MaxDisplacement")) new_criterion = std::make_unique<MaxDisplacement>(tag, node, dof_pool[0], limit);
+        else if(is_equal(criterion_type, "MinDisplacement")) new_criterion = std::make_unique<MinDisplacement>(tag, node, dof_pool[0], limit);
+        else if(is_equal(criterion_type, "MaxResistance")) new_criterion = std::make_unique<MaxResistance>(tag, node, dof_pool[0], limit);
+        else if(is_equal(criterion_type, "MinResistance")) new_criterion = std::make_unique<MinResistance>(tag, node, dof_pool[0], limit);
     }
 
-    if(!flag) suanpan_error("Fail to create new criterion via \"{}\".\n", command.str());
+    if(new_criterion) new_criterion->set_start_step(domain->get_current_step_tag());
+
+    if(!new_criterion || !domain->insert(std::move(new_criterion))) suanpan_error("Fail to create new criterion via \"{}\".\n", command.str());
 
     return SUANPAN_SUCCESS;
 }
@@ -614,10 +610,9 @@ int create_new_constraint(const shared_ptr<DomainBase>& domain, std::istringstre
     else if(is_equal(constraint_id, "Sleeve3D")) new_sleeve<3u>(new_constraint, command);
     else external_module::object(new_constraint, domain, constraint_id, command);
 
-    if(new_constraint != nullptr) new_constraint->set_start_step(domain->get_current_step_tag());
+    if(new_constraint) new_constraint->set_start_step(domain->get_current_step_tag());
 
-    if(new_constraint == nullptr || !domain->insert(std::move(new_constraint)))
-        suanpan_error("Fail to create new constraint via \"{}\".\n", command.str());
+    if(!new_constraint || !domain->insert(std::move(new_constraint))) suanpan_error("Fail to create new constraint via \"{}\".\n", command.str());
 
     return SUANPAN_SUCCESS;
 }

--- a/Constraint/Criterion/ComplementaryEnergyEvolution.cpp
+++ b/Constraint/Criterion/ComplementaryEnergyEvolution.cpp
@@ -19,7 +19,7 @@
 
 #include <Element/Element.h>
 
-ComplementaryEnergyEvolution::ComplementaryEnergyEvolution(const unsigned T, const unsigned ST, const unsigned IL, const unsigned FL, const double WT, const unsigned IT, const unsigned RR, const double PW, const double TL)
-    : EnergyEvolution(T, ST, IL, FL, WT, IT, RR, PW, TL) { get_energy = &Element::get_complementary_energy; }
+ComplementaryEnergyEvolution::ComplementaryEnergyEvolution(const unsigned T, const unsigned IL, const unsigned FL, const double WT, const unsigned IT, const unsigned RR, const double PW, const double TL)
+    : EnergyEvolution(T, IL, FL, WT, IT, RR, PW, TL) { get_energy = &Element::get_complementary_energy; }
 
 unique_ptr<Criterion> ComplementaryEnergyEvolution::unique_copy() { return std::make_unique<ComplementaryEnergyEvolution>(*this); }

--- a/Constraint/Criterion/ComplementaryEnergyEvolution.h
+++ b/Constraint/Criterion/ComplementaryEnergyEvolution.h
@@ -37,7 +37,6 @@ class ComplementaryEnergyEvolution final : public EnergyEvolution {
 public:
     ComplementaryEnergyEvolution(
         unsigned,      // tag
-        unsigned,      // step tag
         unsigned,      // incre level
         unsigned,      // final level
         double = 1.,   // centre weight

--- a/Constraint/Criterion/Criterion.cpp
+++ b/Constraint/Criterion/Criterion.cpp
@@ -19,12 +19,13 @@
 
 #include <Domain/DomainBase.h>
 
-Criterion::Criterion(const unsigned T, const unsigned ST)
-    : CopyableTag(T)
-    , step_tag(ST) {}
+void Criterion::set_start_step(const unsigned ST) { start_step = ST; }
 
-void Criterion::set_step_tag(const unsigned T) { step_tag = T; }
+void Criterion::set_end_step(const unsigned ST) { end_step = ST; }
 
-unsigned Criterion::get_step_tag() const { return step_tag; }
+bool Criterion::if_apply(const shared_ptr<DomainBase>& D) const {
+    const auto t_step = D->get_current_step_tag();
+    return start_step != 0u && t_step >= start_step && t_step < end_step && is_active();
+}
 
 int Criterion::initialize(const shared_ptr<DomainBase>&) { return SUANPAN_SUCCESS; }

--- a/Constraint/Criterion/Criterion.h
+++ b/Constraint/Criterion/Criterion.h
@@ -36,13 +36,15 @@
 class DomainBase;
 
 class Criterion : public CopyableTag {
-    unsigned step_tag;
+    unsigned start_step{static_cast<unsigned>(-1)}, end_step{static_cast<unsigned>(-1)};
 
 public:
-    explicit Criterion(unsigned = 0, unsigned = 0);
+    using CopyableTag::CopyableTag;
 
-    void set_step_tag(unsigned);
-    [[nodiscard]] unsigned get_step_tag() const;
+    void set_start_step(unsigned);
+    void set_end_step(unsigned);
+
+    [[nodiscard]] bool if_apply(const shared_ptr<DomainBase>&) const;
 
     virtual unique_ptr<Criterion> unique_copy() = 0;
 

--- a/Constraint/Criterion/EnergyEvolution.cpp
+++ b/Constraint/Criterion/EnergyEvolution.cpp
@@ -21,8 +21,8 @@
 #include <Element/Element.h>
 #include <Step/Step.h>
 
-EnergyEvolution::EnergyEvolution(const unsigned T, const unsigned ST, const unsigned IL, const unsigned FL, const double WT, const unsigned IT, const unsigned RR, const double PW, const double TL)
-    : Criterion(T, ST)
+EnergyEvolution::EnergyEvolution(const unsigned T, const unsigned IL, const unsigned FL, const double WT, const unsigned IT, const unsigned RR, const double PW, const double TL)
+    : Criterion(T)
     , iteration(IT)
     , reactive_ratio(RR)
     , incre_level(IL)

--- a/Constraint/Criterion/EnergyEvolution.h
+++ b/Constraint/Criterion/EnergyEvolution.h
@@ -62,7 +62,6 @@ protected:
 public:
     EnergyEvolution(
         unsigned,      // tag
-        unsigned,      // step tag
         unsigned,      // incre level
         unsigned,      // final level
         double = 1.,   // centre weight

--- a/Constraint/Criterion/LogicCriterion.cpp
+++ b/Constraint/Criterion/LogicCriterion.cpp
@@ -19,8 +19,8 @@
 
 #include <Domain/DomainBase.h>
 
-LogicCriterion::LogicCriterion(const unsigned T, const unsigned ST, const unsigned TA, const unsigned TB)
-    : Criterion(T, ST)
+LogicCriterion::LogicCriterion(const unsigned T, const unsigned TA, const unsigned TB)
+    : Criterion(T)
     , tag_a(TA)
     , tag_b(TB) {}
 

--- a/Constraint/Criterion/LogicCriterion.h
+++ b/Constraint/Criterion/LogicCriterion.h
@@ -40,7 +40,7 @@ protected:
     shared_ptr<Criterion> criterion_a, criterion_b;
 
 public:
-    explicit LogicCriterion(unsigned, unsigned, unsigned, unsigned);
+    LogicCriterion(unsigned, unsigned, unsigned);
 
     int initialize(const shared_ptr<DomainBase>&) override;
 };

--- a/Constraint/Criterion/MinMaxHistory.cpp
+++ b/Constraint/Criterion/MinMaxHistory.cpp
@@ -20,8 +20,8 @@
 #include <Domain/DomainBase.h>
 #include <Element/Element.h>
 
-HistoryCriterion::HistoryCriterion(const unsigned T, const unsigned ST, const OutputType HT, const double MH, uvec&& IDX)
-    : Criterion(T, ST)
+HistoryCriterion::HistoryCriterion(const unsigned T, const OutputType HT, const double MH, uvec&& IDX)
+    : Criterion(T)
     , indices(IDX)
     , limit(MH)
     , history_type(HT) {}

--- a/Constraint/Criterion/MinMaxHistory.h
+++ b/Constraint/Criterion/MinMaxHistory.h
@@ -49,7 +49,6 @@ private:
 public:
     HistoryCriterion(
         unsigned,   // tag
-        unsigned,   // step tag
         OutputType, // history type
         double,     // limit
         uvec&&      // indices

--- a/Constraint/Criterion/NodeBasedCriterion.cpp
+++ b/Constraint/Criterion/NodeBasedCriterion.cpp
@@ -21,8 +21,8 @@
 
 std::vector<uword> NodeBasedCriterion::get_dof(const shared_ptr<DomainBase>& D) const { return D->get_node(node)->get_dof({dof}); }
 
-NodeBasedCriterion::NodeBasedCriterion(const unsigned T, const unsigned ST, const unsigned NT, const Node::DOF DT, const double MA)
-    : Criterion(T, ST)
+NodeBasedCriterion::NodeBasedCriterion(const unsigned T, const unsigned NT, const Node::DOF DT, const double MA)
+    : Criterion(T)
     , limit(MA)
     , node(NT)
     , dof(DT) {}

--- a/Constraint/Criterion/NodeBasedCriterion.h
+++ b/Constraint/Criterion/NodeBasedCriterion.h
@@ -40,12 +40,11 @@ protected:
     const unsigned node;
     const Node::DOF dof;
 
-    std::vector<uword> get_dof(const shared_ptr<DomainBase>&) const;
+    [[nodiscard]] std::vector<uword> get_dof(const shared_ptr<DomainBase>&) const;
 
 public:
     NodeBasedCriterion(
         unsigned,  // tag
-        unsigned,  // step tag
         unsigned,  // node tag
         Node::DOF, // dof tag
         double     // limit

--- a/Constraint/Criterion/StrainEnergyEvolution.cpp
+++ b/Constraint/Criterion/StrainEnergyEvolution.cpp
@@ -19,7 +19,7 @@
 
 #include <Element/Element.h>
 
-StrainEnergyEvolution::StrainEnergyEvolution(const unsigned T, const unsigned ST, const unsigned IL, const unsigned FL, const double WT, const unsigned IT, const unsigned RR, const double PW, const double TL)
-    : EnergyEvolution(T, ST, IL, FL, WT, IT, RR, PW, TL) { get_energy = &Element::get_strain_energy; }
+StrainEnergyEvolution::StrainEnergyEvolution(const unsigned T, const unsigned IL, const unsigned FL, const double WT, const unsigned IT, const unsigned RR, const double PW, const double TL)
+    : EnergyEvolution(T, IL, FL, WT, IT, RR, PW, TL) { get_energy = &Element::get_strain_energy; }
 
 unique_ptr<Criterion> StrainEnergyEvolution::unique_copy() { return std::make_unique<StrainEnergyEvolution>(*this); }

--- a/Constraint/Criterion/StrainEnergyEvolution.h
+++ b/Constraint/Criterion/StrainEnergyEvolution.h
@@ -37,7 +37,6 @@ class StrainEnergyEvolution final : public EnergyEvolution {
 public:
     StrainEnergyEvolution(
         unsigned,      // tag
-        unsigned,      // step tag
         unsigned,      // incre level
         unsigned,      // final level
         double = 1.,   // centre weight

--- a/Domain/Domain.cpp
+++ b/Domain/Domain.cpp
@@ -1320,7 +1320,8 @@ int Domain::process_constraint(const bool full) {
 
 int Domain::process_criterion() {
     auto code = 0;
-    for(auto& I : criterion_pond.get()) code += I->process(shared_from_this());
+    for(auto& I : criterion_pond.get())
+        if(I->if_apply(shared_from_this())) code += I->process(shared_from_this());
     return code;
 }
 

--- a/Toolbox/command.cpp
+++ b/Toolbox/command.cpp
@@ -857,6 +857,10 @@ namespace {
             while(!command.eof() && get_input(command, tag)) {
                 if(domain->find_load(tag)) domain->get_load(tag)->set_end_step(step_tag);
             }
+        else if(is_equal(object_type, "criterion"))
+            while(!command.eof() && get_input(command, tag)) {
+                if(domain->find_criterion(tag)) domain->get_criterion(tag)->set_end_step(step_tag);
+            }
 
         return SUANPAN_SUCCESS;
     }


### PR DESCRIPTION
Refactor the handling of criteria in command processing by removing the step tag from constructors and updating related logic. This change simplifies the criterion structure and enhances the clarity of the code.