### PR TITLE
Refactor LogicCriterion and rename criteria for clarity

### DIFF
--- a/Constraint/ConstraintParser.cpp
+++ b/Constraint/ConstraintParser.cpp
@@ -427,14 +427,14 @@ int create_new_criterion(const shared_ptr<DomainBase>& domain, std::istringstrea
     unique_ptr<Criterion> new_criterion = nullptr;
 
     if(is_equal(criterion_type.substr(0, 5), "Logic")) {
-        unsigned tag_a, tag_b;
-        if(!get_input(command, tag_a, tag_b)) {
-            suanpan_error("A valid tag is required.\n");
+        auto tags = get_remaining<unsigned>(command);
+        if(tags.empty()) {
+            suanpan_error("At least one valid tag is required.\n");
             return SUANPAN_SUCCESS;
         }
 
-        if(is_equal_any(criterion_type, "LogicAND", "LogicCriterionAND")) new_criterion = std::make_unique<LogicCriterionAND>(tag, tag_a, tag_b);
-        else if(is_equal_any(criterion_type, "LogicOR", "LogicCriterionOR")) new_criterion = std::make_unique<LogicCriterionOR>(tag, tag_a, tag_b);
+        if(is_equal_any(criterion_type, "LogicAll", "LogicCriterionAll")) new_criterion = std::make_unique<LogicCriterionAll>(tag, std::move(tags));
+        else if(is_equal_any(criterion_type, "LogicAny", "LogicCriterionAny")) new_criterion = std::make_unique<LogicCriterionAny>(tag, std::move(tags));
     }
     else if(is_equal(criterion_type, "StrainEnergyEvolution")) {
         unsigned incre_level, final_level;

--- a/Constraint/Criterion/LogicCriterion.cpp
+++ b/Constraint/Criterion/LogicCriterion.cpp
@@ -19,45 +19,50 @@
 
 #include <Domain/DomainBase.h>
 
-LogicCriterion::LogicCriterion(const unsigned T, const unsigned TA, const unsigned TB)
+LogicCriterion::LogicCriterion(const unsigned T, std::vector<unsigned>&& TT)
     : Criterion(T)
-    , tag_a(TA)
-    , tag_b(TB) {}
+    , tags(std::move(TT)) {}
 
 int LogicCriterion::initialize(const shared_ptr<DomainBase>& D) {
-    const auto& t_criterion_a = D->get<Criterion>(tag_a);
-    const auto& t_criterion_b = D->get<Criterion>(tag_b);
+    criteria.clear();
+    criteria.reserve(tags.size());
 
-    if(nullptr == t_criterion_a || nullptr == t_criterion_b) {
-        suanpan_error("Cannot find criteria {} and/or {}.\n", tag_a, tag_b);
-        D->disable_criterion(get_tag());
-        return SUANPAN_SUCCESS;
-    }
+    for(const auto t_tag : tags) {
+        const auto& t_criterion = D->get<Criterion>(t_tag);
+        if(!t_criterion) {
+            suanpan_error("Cannot find criterion {}.\n", t_tag);
+            D->disable_criterion(get_tag());
+            return SUANPAN_SUCCESS;
+        }
 
-    criterion_a = t_criterion_a->unique_copy();
-    criterion_b = t_criterion_b->unique_copy();
+        const auto& t_copy = criteria.emplace_back(t_criterion->unique_copy());
 
-    if(SUANPAN_SUCCESS != criterion_a->initialize(D) || SUANPAN_SUCCESS != criterion_b->initialize(D)) {
-        suanpan_error("Fail to initialize criteria {} and/or {}.\n", tag_a, tag_b);
-        D->disable_criterion(get_tag());
+        if(SUANPAN_SUCCESS != t_copy->initialize(D)) {
+            suanpan_error("Fail to initialize criterion {}.\n", t_tag);
+            D->disable_criterion(get_tag());
+            return SUANPAN_SUCCESS;
+        }
     }
 
     return SUANPAN_SUCCESS;
 }
 
 int LogicCriterion::process(const shared_ptr<DomainBase>& D) {
-    const auto result_a = criterion_a->process(D);
-    const auto result_b = criterion_b->process(D);
+    std::vector<int> results;
+    for(const auto& t_criterion : criteria)
+        if(SUANPAN_FAIL == results.emplace_back(t_criterion->process(D))) return SUANPAN_FAIL;
 
-    if(SUANPAN_FAIL == result_a || SUANPAN_FAIL == result_b) return SUANPAN_FAIL;
-
-    return check(result_a, result_b);
+    return check(results);
 }
 
-int LogicCriterionAND::check(const int result_a, const int result_b) const { return SUANPAN_EXIT == result_a && SUANPAN_EXIT == result_b; }
+int LogicCriterionAND::check(const std::vector<int>& results) const {
+    return std::ranges::all_of(results, [](const int result) { return SUANPAN_EXIT == result; });
+}
 
 unique_ptr<Criterion> LogicCriterionAND::unique_copy() { return std::make_unique<LogicCriterionAND>(*this); }
 
-int LogicCriterionOR::check(const int result_a, const int result_b) const { return SUANPAN_EXIT == result_a || SUANPAN_EXIT == result_b; }
+int LogicCriterionOR::check(const std::vector<int>& results) const {
+    return std::ranges::any_of(results, [](const int result) { return SUANPAN_EXIT == result; });
+}
 
 unique_ptr<Criterion> LogicCriterionOR::unique_copy() { return std::make_unique<LogicCriterionOR>(*this); }

--- a/Constraint/Criterion/LogicCriterion.cpp
+++ b/Constraint/Criterion/LogicCriterion.cpp
@@ -35,9 +35,7 @@ int LogicCriterion::initialize(const shared_ptr<DomainBase>& D) {
             return SUANPAN_SUCCESS;
         }
 
-        const auto& t_copy = criteria.emplace_back(t_criterion->unique_copy());
-
-        if(SUANPAN_SUCCESS != t_copy->initialize(D)) {
+        if(const auto& t_copy = criteria.emplace_back(t_criterion->unique_copy()); SUANPAN_SUCCESS != t_copy->initialize(D)) {
             suanpan_error("Fail to initialize criterion {}.\n", t_tag);
             D->disable_criterion(get_tag());
             return SUANPAN_SUCCESS;
@@ -55,14 +53,14 @@ int LogicCriterion::process(const shared_ptr<DomainBase>& D) {
     return check(results);
 }
 
-int LogicCriterionAND::check(const std::vector<int>& results) const {
+int LogicCriterionAll::check(const std::vector<int>& results) const {
     return std::ranges::all_of(results, [](const int result) { return SUANPAN_EXIT == result; });
 }
 
-unique_ptr<Criterion> LogicCriterionAND::unique_copy() { return std::make_unique<LogicCriterionAND>(*this); }
+unique_ptr<Criterion> LogicCriterionAll::unique_copy() { return std::make_unique<LogicCriterionAll>(*this); }
 
-int LogicCriterionOR::check(const std::vector<int>& results) const {
+int LogicCriterionAny::check(const std::vector<int>& results) const {
     return std::ranges::any_of(results, [](const int result) { return SUANPAN_EXIT == result; });
 }
 
-unique_ptr<Criterion> LogicCriterionOR::unique_copy() { return std::make_unique<LogicCriterionOR>(*this); }
+unique_ptr<Criterion> LogicCriterionAny::unique_copy() { return std::make_unique<LogicCriterionAny>(*this); }

--- a/Constraint/Criterion/LogicCriterion.h
+++ b/Constraint/Criterion/LogicCriterion.h
@@ -49,7 +49,7 @@ public:
     int process(const shared_ptr<DomainBase>&) final;
 };
 
-class LogicCriterionAND final : public LogicCriterion {
+class LogicCriterionAll final : public LogicCriterion {
     [[nodiscard]] int check(const std::vector<int>&) const override;
 
 public:
@@ -58,7 +58,7 @@ public:
     unique_ptr<Criterion> unique_copy() override;
 };
 
-class LogicCriterionOR final : public LogicCriterion {
+class LogicCriterionAny final : public LogicCriterion {
     [[nodiscard]] int check(const std::vector<int>&) const override;
 
 public:

--- a/Constraint/Criterion/LogicCriterion.h
+++ b/Constraint/Criterion/LogicCriterion.h
@@ -34,15 +34,15 @@
 #include "Criterion.h"
 
 class LogicCriterion : public Criterion {
-    const unsigned tag_a, tag_b;
+    const std::vector<unsigned> tags;
 
-    [[nodiscard]] virtual int check(int, int) const = 0;
+    [[nodiscard]] virtual int check(const std::vector<int>&) const = 0;
 
 protected:
-    shared_ptr<Criterion> criterion_a, criterion_b;
+    std::vector<shared_ptr<Criterion>> criteria;
 
 public:
-    LogicCriterion(unsigned, unsigned, unsigned);
+    LogicCriterion(unsigned, std::vector<unsigned>&&);
 
     int initialize(const shared_ptr<DomainBase>&) override;
 
@@ -50,7 +50,7 @@ public:
 };
 
 class LogicCriterionAND final : public LogicCriterion {
-    [[nodiscard]] int check(int, int) const override;
+    [[nodiscard]] int check(const std::vector<int>&) const override;
 
 public:
     using LogicCriterion::LogicCriterion;
@@ -59,7 +59,7 @@ public:
 };
 
 class LogicCriterionOR final : public LogicCriterion {
-    [[nodiscard]] int check(int, int) const override;
+    [[nodiscard]] int check(const std::vector<int>&) const override;
 
 public:
     using LogicCriterion::LogicCriterion;

--- a/Enhancement/suanPan.sublime-completions
+++ b/Enhancement/suanPan.sublime-completions
@@ -1273,16 +1273,16 @@
       "contents": "converger LogicXOR ${1:(1)} ${2:(2)} ${3:(3)}\n# (1) int, unique converger tag\n# (2) int, tag of first converger in logical operation\n# (3) int, tag of second converger in logical operation"
     },
     {
-      "trigger": "LogicCriterionAND",
-      "details": "apply logical operations to two criteria.",
+      "trigger": "LogicCriterionAll",
+      "details": "apply logical operations to multiple criteria.",
       "kind": "type",
-      "contents": "criterion LogicAND ${1:(1)} ${2:(2)} ${3:(3)}\n# (1) int, unique criterion tag\n# (2) int, tag of first criterion in logical operation\n# (3) int, tag of second criterion in logical operation"
+      "contents": "criterion LogicAll ${1:(1)} ${2:((2)...)}\n# (1) int, unique criterion tag\n# (2) int, tags of criteria in logical operation"
     },
     {
-      "trigger": "LogicCriterionOR",
-      "details": "apply logical operations to two criteria.",
+      "trigger": "LogicCriterionAny",
+      "details": "apply logical operations to multiple criteria.",
       "kind": "type",
-      "contents": "criterion LogicOR ${1:(1)} ${2:(2)} ${3:(3)}\n# (1) int, unique criterion tag\n# (2) int, tag of first criterion in logical operation\n# (3) int, tag of second criterion in logical operation"
+      "contents": "criterion LogicAny ${1:(1)} ${2:((2)...)}\n# (1) int, unique criterion tag\n# (2) int, tags of criteria in logical operation"
     },
     {
       "trigger": "LumpedScale",

--- a/Example/Other/MaxHistory.supan
+++ b/Example/Other/MaxHistory.supan
@@ -33,7 +33,7 @@ set fixed_step_size 1
 
 converger RelIncreDisp 1 1e-10 10 1
 
-criterion LogicOR 3 1 2
+criterion LogicAny 3 1 2
 
 analyze
 


### PR DESCRIPTION
Refactor LogicCriterion to utilize a vector for tags, enhancing initialization and processing logic. Rename LogicCriterionAND to LogicCriterionAll and LogicCriterionOR to LogicCriterionAny for improved clarity and functionality. This change streamlines the handling of multiple criteria.