### PR TITLE
Add independent CoupleMaterial implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## version 4.2
 
 1. (**breaking**) change the behaviour of criterion DoF tokens, similar to the change made in v4.0, use explicit tokens for unconventional DoFs [#368](https://github.com/TLCFEM/suanPan/pull/368)
+2. reduce memory footprint by isolating couple stress implementation [#378](https://github.com/TLCFEM/suanPan/pull/378)
 
 ## version 4.1.1
 

--- a/Element/Membrane/CSM/CSMQ.cpp
+++ b/Element/Membrane/CSM/CSMQ.cpp
@@ -37,12 +37,14 @@ CSMQ::CSMQ(const unsigned T, uvec&& N, const unsigned M, const unsigned NN, cons
 int CSMQ::initialize(const shared_ptr<DomainBase>& D) {
     auto& material_proto = D->get<Material>(material_tag(0));
 
-    if(!material_proto->is_support_couple()) {
-        suanpan_warning("Element {} is assigned with a material that does not support couple stress.\n", get_tag());
-        return SUANPAN_FAIL;
-    }
+    auto elastic_modulus = material_proto->get(Material::Parameter::ELASTIC);
+    auto poissons_ratio = material_proto->get(Material::Parameter::POISSON);
 
-    if(PlaneType::E == material_proto->get_plane_type()) suanpan::hacker(thickness) = 1.;
+    if(PlaneType::E == material_proto->get_plane_type()) {
+        suanpan::hacker(thickness) = 1.;
+        elastic_modulus /= 1. - poissons_ratio * poissons_ratio;
+        poissons_ratio /= 1. - poissons_ratio;
+    }
 
     const auto ele_coor = get_coordinate(2);
 
@@ -70,8 +72,8 @@ int CSMQ::initialize(const shared_ptr<DomainBase>& D) {
 
         auto& c_pt = int_pt.back();
 
-        c_pt.m_material->set_characteristic_length(characteristic_length);
-        c_pt.m_material->initialize_couple(D);
+        c_pt.m_couple = std::make_unique<IsotropicCouple>(elastic_modulus, poissons_ratio, characteristic_length);
+        c_pt.m_couple->initialize(D);
 
         mat phi_s(2, t_size, fill::zeros), l_p(3, t_size, fill::zeros), j_p(1, t_size, fill::zeros), j_q(2, r_size, fill::zeros);
 
@@ -94,7 +96,7 @@ int CSMQ::initialize(const shared_ptr<DomainBase>& D) {
         const mat phi_a = shape::stress11(location(0), location(1));
         const mat phi_b = solve(c_pt.m_material->get_initial_stiffness(), phi_a);
 
-        E1 += c_pt.weight * phi_r.t() * c_pt.m_material->get_initial_couple_stiffness() * phi_r;
+        E1 += c_pt.weight * phi_r.t() * c_pt.m_couple->get_initial_stiffness() * phi_r;
         E2 += c_pt.weight * phi_b.t() * c_pt.m_material->get_initial_stiffness() * phi_b;
         H1 -= 2. * c_pt.weight * j_p.t() * j_s;
         H2 += c_pt.weight * l_p.t() * phi_a;
@@ -160,15 +162,15 @@ int CSMQ::update_status() {
 
     for(const auto& I : int_pt) {
         if(SUANPAN_SUCCESS != I.m_material->update_trial_status(I.b1 * t_disp(t_dof))) return SUANPAN_FAIL;
-        if(SUANPAN_SUCCESS != I.m_material->update_couple_trial_status(I.b2 * t_disp(t_dof) + I.b3 * t_disp(r_dof))) return SUANPAN_FAIL;
+        if(SUANPAN_SUCCESS != I.m_couple->update_trial_status(I.b2 * t_disp(t_dof) + I.b3 * t_disp(r_dof))) return SUANPAN_FAIL;
 
-        trial_stiffness(t_dof, t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stiffness() * I.b1 + I.weight * I.b2.t() * I.m_material->get_trial_couple_stiffness() * I.b2;
-        trial_stiffness(t_dof, r_dof) += I.weight * I.b2.t() * I.m_material->get_trial_couple_stiffness() * I.b3;
-        trial_stiffness(r_dof, t_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stiffness() * I.b2;
-        trial_stiffness(r_dof, r_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stiffness() * I.b3;
+        trial_stiffness(t_dof, t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stiffness() * I.b1 + I.weight * I.b2.t() * I.m_couple->get_trial_stiffness() * I.b2;
+        trial_stiffness(t_dof, r_dof) += I.weight * I.b2.t() * I.m_couple->get_trial_stiffness() * I.b3;
+        trial_stiffness(r_dof, t_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_stiffness() * I.b2;
+        trial_stiffness(r_dof, r_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_stiffness() * I.b3;
 
-        trial_resistance(t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stress() + I.weight * I.b2.t() * I.m_material->get_trial_couple_stress();
-        trial_resistance(r_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stress();
+        trial_resistance(t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stress() + I.weight * I.b2.t() * I.m_couple->get_trial_moment();
+        trial_resistance(r_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_moment();
     }
 
     return SUANPAN_SUCCESS;
@@ -176,19 +178,19 @@ int CSMQ::update_status() {
 
 int CSMQ::commit_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->commit_status() + I.m_material->commit_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->commit_status() + I.m_couple->commit_status();
     return code;
 }
 
 int CSMQ::clear_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->clear_status() + I.m_material->clear_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->clear_status() + I.m_couple->clear_status();
     return code;
 }
 
 int CSMQ::reset_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->reset_status() + I.m_material->reset_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->reset_status() + I.m_couple->reset_status();
     return code;
 }
 

--- a/Element/Membrane/CSM/CSMQ.h
+++ b/Element/Membrane/CSM/CSMQ.h
@@ -31,12 +31,14 @@
 #define CSMQ_H
 
 #include <Element/MaterialElement.h>
+#include <Material/CoupleMaterial.h>
 
 class CSMQ : public MaterialElement2D {
     struct IntegrationPoint final {
         vec coor;
         double weight;
         unique_ptr<Material> m_material;
+        unique_ptr<IsotropicCouple> m_couple;
         mat b1, b2, b3;
         IntegrationPoint(vec&&, double, unique_ptr<Material>&&);
     };

--- a/Element/Membrane/CSM/CSMQ4.cpp
+++ b/Element/Membrane/CSM/CSMQ4.cpp
@@ -39,12 +39,14 @@ CSMQ4::CSMQ4(const unsigned T, uvec&& N, const unsigned M, const double TH, cons
 int CSMQ4::initialize(const shared_ptr<DomainBase>& D) {
     auto& material_proto = D->get<Material>(material_tag(0));
 
-    if(!material_proto->is_support_couple()) {
-        suanpan_warning("Element {} is assigned with a material that does not support couple stress.\n", get_tag());
-        return SUANPAN_FAIL;
-    }
+    auto elastic_modulus = material_proto->get(Material::Parameter::ELASTIC);
+    auto poissons_ratio = material_proto->get(Material::Parameter::POISSON);
 
-    if(PlaneType::E == material_proto->get_plane_type()) suanpan::hacker(thickness) = 1.;
+    if(PlaneType::E == material_proto->get_plane_type()) {
+        suanpan::hacker(thickness) = 1.;
+        elastic_modulus /= 1. - poissons_ratio * poissons_ratio;
+        poissons_ratio /= 1. - poissons_ratio;
+    }
 
     const auto ele_coor = get_coordinate(2);
 
@@ -68,8 +70,8 @@ int CSMQ4::initialize(const shared_ptr<DomainBase>& D) {
 
         auto& c_pt = int_pt.back();
 
-        c_pt.m_material->set_characteristic_length(characteristic_length);
-        c_pt.m_material->initialize_couple(D);
+        c_pt.m_couple = std::make_unique<IsotropicCouple>(elastic_modulus, poissons_ratio, characteristic_length);
+        c_pt.m_couple->initialize(D);
 
         mat phi_s(2, t_size, fill::zeros), l_p(3, t_size, fill::zeros), j_p(1, t_size, fill::zeros), j_q(2, r_size, fill::zeros);
 
@@ -92,7 +94,7 @@ int CSMQ4::initialize(const shared_ptr<DomainBase>& D) {
         const mat phi_a = shape::linear_stress(location(0), location(1));
         const mat phi_b = solve(c_pt.m_material->get_initial_stiffness(), phi_a);
 
-        E1 += c_pt.weight * phi_r.t() * c_pt.m_material->get_initial_couple_stiffness() * phi_r;
+        E1 += c_pt.weight * phi_r.t() * c_pt.m_couple->get_initial_stiffness() * phi_r;
         E2 += c_pt.weight * phi_b.t() * c_pt.m_material->get_initial_stiffness() * phi_b;
         H1 -= 2. * c_pt.weight * j_p.t() * j_s;
         H2 += c_pt.weight * l_p.t() * phi_a;
@@ -155,15 +157,15 @@ int CSMQ4::update_status() {
 
     for(const auto& I : int_pt) {
         if(SUANPAN_SUCCESS != I.m_material->update_trial_status(I.b1 * t_disp(t_dof))) return SUANPAN_FAIL;
-        if(SUANPAN_SUCCESS != I.m_material->update_couple_trial_status(I.b2 * t_disp(t_dof) + I.b3 * t_disp(r_dof))) return SUANPAN_FAIL;
+        if(SUANPAN_SUCCESS != I.m_couple->update_trial_status(I.b2 * t_disp(t_dof) + I.b3 * t_disp(r_dof))) return SUANPAN_FAIL;
 
-        trial_stiffness(t_dof, t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stiffness() * I.b1 + I.weight * I.b2.t() * I.m_material->get_trial_couple_stiffness() * I.b2;
-        trial_stiffness(t_dof, r_dof) += I.weight * I.b2.t() * I.m_material->get_trial_couple_stiffness() * I.b3;
-        trial_stiffness(r_dof, t_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stiffness() * I.b2;
-        trial_stiffness(r_dof, r_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stiffness() * I.b3;
+        trial_stiffness(t_dof, t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stiffness() * I.b1 + I.weight * I.b2.t() * I.m_couple->get_trial_stiffness() * I.b2;
+        trial_stiffness(t_dof, r_dof) += I.weight * I.b2.t() * I.m_couple->get_trial_stiffness() * I.b3;
+        trial_stiffness(r_dof, t_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_stiffness() * I.b2;
+        trial_stiffness(r_dof, r_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_stiffness() * I.b3;
 
-        trial_resistance(t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stress() + I.weight * I.b2.t() * I.m_material->get_trial_couple_stress();
-        trial_resistance(r_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stress();
+        trial_resistance(t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stress() + I.weight * I.b2.t() * I.m_couple->get_trial_moment();
+        trial_resistance(r_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_moment();
     }
 
     return SUANPAN_SUCCESS;
@@ -171,19 +173,19 @@ int CSMQ4::update_status() {
 
 int CSMQ4::commit_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->commit_status() + I.m_material->commit_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->commit_status() + I.m_couple->commit_status();
     return code;
 }
 
 int CSMQ4::clear_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->clear_status() + I.m_material->clear_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->clear_status() + I.m_couple->clear_status();
     return code;
 }
 
 int CSMQ4::reset_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->reset_status() + I.m_material->reset_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->reset_status() + I.m_couple->reset_status();
     return code;
 }
 

--- a/Element/Membrane/CSM/CSMQ4.h
+++ b/Element/Membrane/CSM/CSMQ4.h
@@ -31,12 +31,14 @@
 #define CSMQ4_H
 
 #include <Element/MaterialElement.h>
+#include <Material/CoupleMaterial.h>
 
 class CSMQ4 final : public MaterialElement2D {
     struct IntegrationPoint final {
         vec coor;
         double weight;
         unique_ptr<Material> m_material;
+        unique_ptr<IsotropicCouple> m_couple;
         mat b1, b2, b3;
         IntegrationPoint(vec&&, double, unique_ptr<Material>&&);
     };

--- a/Element/Membrane/CSM/CSMQ8.cpp
+++ b/Element/Membrane/CSM/CSMQ8.cpp
@@ -39,12 +39,14 @@ CSMQ8::CSMQ8(const unsigned T, uvec&& N, const unsigned M, const double TH, cons
 int CSMQ8::initialize(const shared_ptr<DomainBase>& D) {
     auto& material_proto = D->get<Material>(material_tag(0));
 
-    if(!material_proto->is_support_couple()) {
-        suanpan_warning("Element {} is assigned with a material that does not support couple stress.\n", get_tag());
-        return SUANPAN_FAIL;
-    }
+    auto elastic_modulus = material_proto->get(Material::Parameter::ELASTIC);
+    auto poissons_ratio = material_proto->get(Material::Parameter::POISSON);
 
-    if(PlaneType::E == material_proto->get_plane_type()) suanpan::hacker(thickness) = 1.;
+    if(PlaneType::E == material_proto->get_plane_type()) {
+        suanpan::hacker(thickness) = 1.;
+        elastic_modulus /= 1. - poissons_ratio * poissons_ratio;
+        poissons_ratio /= 1. - poissons_ratio;
+    }
 
     const auto ele_coor = get_coordinate(2);
 
@@ -68,8 +70,8 @@ int CSMQ8::initialize(const shared_ptr<DomainBase>& D) {
 
         auto& c_pt = int_pt.back();
 
-        c_pt.m_material->set_characteristic_length(characteristic_length);
-        c_pt.m_material->initialize_couple(D);
+        c_pt.m_couple = std::make_unique<IsotropicCouple>(elastic_modulus, poissons_ratio, characteristic_length);
+        c_pt.m_couple->initialize(D);
 
         mat phi_s(2, t_size, fill::zeros), l_p(3, t_size, fill::zeros), j_p(1, t_size, fill::zeros), j_q(2, r_size, fill::zeros);
 
@@ -92,7 +94,7 @@ int CSMQ8::initialize(const shared_ptr<DomainBase>& D) {
         const mat phi_a = shape::stress11(location(0), location(1));
         const mat phi_b = solve(c_pt.m_material->get_initial_stiffness(), phi_a);
 
-        E1 += c_pt.weight * phi_r.t() * c_pt.m_material->get_initial_couple_stiffness() * phi_r;
+        E1 += c_pt.weight * phi_r.t() * c_pt.m_couple->get_initial_stiffness() * phi_r;
         E2 += c_pt.weight * phi_b.t() * c_pt.m_material->get_initial_stiffness() * phi_b;
         H1 -= 2. * c_pt.weight * j_p.t() * j_s;
         H2 += c_pt.weight * l_p.t() * phi_a;
@@ -155,15 +157,15 @@ int CSMQ8::update_status() {
 
     for(const auto& I : int_pt) {
         if(SUANPAN_SUCCESS != I.m_material->update_trial_status(I.b1 * t_disp(t_dof))) return SUANPAN_FAIL;
-        if(SUANPAN_SUCCESS != I.m_material->update_couple_trial_status(I.b2 * t_disp(t_dof) + I.b3 * t_disp(r_dof))) return SUANPAN_FAIL;
+        if(SUANPAN_SUCCESS != I.m_couple->update_trial_status(I.b2 * t_disp(t_dof) + I.b3 * t_disp(r_dof))) return SUANPAN_FAIL;
 
-        trial_stiffness(t_dof, t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stiffness() * I.b1 + I.weight * I.b2.t() * I.m_material->get_trial_couple_stiffness() * I.b2;
-        trial_stiffness(t_dof, r_dof) += I.weight * I.b2.t() * I.m_material->get_trial_couple_stiffness() * I.b3;
-        trial_stiffness(r_dof, t_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stiffness() * I.b2;
-        trial_stiffness(r_dof, r_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stiffness() * I.b3;
+        trial_stiffness(t_dof, t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stiffness() * I.b1 + I.weight * I.b2.t() * I.m_couple->get_trial_stiffness() * I.b2;
+        trial_stiffness(t_dof, r_dof) += I.weight * I.b2.t() * I.m_couple->get_trial_stiffness() * I.b3;
+        trial_stiffness(r_dof, t_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_stiffness() * I.b2;
+        trial_stiffness(r_dof, r_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_stiffness() * I.b3;
 
-        trial_resistance(t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stress() + I.weight * I.b2.t() * I.m_material->get_trial_couple_stress();
-        trial_resistance(r_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stress();
+        trial_resistance(t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stress() + I.weight * I.b2.t() * I.m_couple->get_trial_moment();
+        trial_resistance(r_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_moment();
     }
 
     return SUANPAN_SUCCESS;
@@ -171,19 +173,19 @@ int CSMQ8::update_status() {
 
 int CSMQ8::commit_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->commit_status() + I.m_material->commit_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->commit_status() + I.m_couple->commit_status();
     return code;
 }
 
 int CSMQ8::clear_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->clear_status() + I.m_material->clear_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->clear_status() + I.m_couple->clear_status();
     return code;
 }
 
 int CSMQ8::reset_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->reset_status() + I.m_material->reset_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->reset_status() + I.m_couple->reset_status();
     return code;
 }
 

--- a/Element/Membrane/CSM/CSMQ8.h
+++ b/Element/Membrane/CSM/CSMQ8.h
@@ -31,12 +31,14 @@
 #define CSMQ8_H
 
 #include <Element/MaterialElement.h>
+#include <Material/CoupleMaterial.h>
 
 class CSMQ8 final : public MaterialElement2D {
     struct IntegrationPoint final {
         vec coor;
         double weight;
         unique_ptr<Material> m_material;
+        unique_ptr<IsotropicCouple> m_couple;
         mat b1, b2, b3;
         IntegrationPoint(vec&&, double, unique_ptr<Material>&&);
     };

--- a/Element/Membrane/CSM/CSMT3.cpp
+++ b/Element/Membrane/CSM/CSMT3.cpp
@@ -36,12 +36,14 @@ CSMT3::CSMT3(const unsigned T, uvec&& NT, const unsigned MT, const double TH, co
 int CSMT3::initialize(const shared_ptr<DomainBase>& D) {
     auto& material_proto = D->get<Material>(material_tag(0));
 
-    if(!material_proto->is_support_couple()) {
-        suanpan_warning("Element {} is assigned with a material that does not support couple stress.\n", get_tag());
-        return SUANPAN_FAIL;
-    }
+    auto elastic_modulus = material_proto->get(Material::Parameter::ELASTIC);
+    auto poissons_ratio = material_proto->get(Material::Parameter::POISSON);
 
-    if(PlaneType::E == material_proto->get_plane_type()) suanpan::hacker(thickness) = 1.;
+    if(PlaneType::E == material_proto->get_plane_type()) {
+        suanpan::hacker(thickness) = 1.;
+        elastic_modulus /= 1. - poissons_ratio * poissons_ratio;
+        poissons_ratio /= 1. - poissons_ratio;
+    }
 
     mat ele_coor(m_node, m_node);
     ele_coor.col(0).fill(1.);
@@ -107,8 +109,8 @@ int CSMT3::initialize(const shared_ptr<DomainBase>& D) {
     mat E1(t_size, t_size, fill::zeros), H3(r_size, t_size, fill::zeros), H4(t_size, t_size, fill::zeros);
 
     for(auto& I : int_pt) {
-        I.m_material->set_characteristic_length(characteristic_length);
-        I.m_material->initialize_couple(D);
+        I.m_couple = std::make_unique<IsotropicCouple>(elastic_modulus, poissons_ratio, characteristic_length);
+        I.m_couple->initialize(D);
 
         const rowvec n = I.coor * inv_coor;
 
@@ -127,7 +129,7 @@ int CSMT3::initialize(const shared_ptr<DomainBase>& D) {
 
             phi_s(0, K) = phi_s(1, L) = n(J);
 
-        E1 += I.weight * phi_r.t() * I.m_material->get_initial_couple_stiffness() * phi_r;
+        E1 += I.weight * phi_r.t() * I.m_couple->get_initial_stiffness() * phi_r;
         H3 += 2. * I.weight * (phi_q.t() * j_s - j_q.t() * phi_s);
         H4 += I.weight * phi_r.t() * phi_s;
 
@@ -164,15 +166,15 @@ int CSMT3::update_status() {
 
     for(const auto& I : int_pt) {
         if(SUANPAN_SUCCESS != I.m_material->update_trial_status(I.b1 * t_disp(t_dof))) return SUANPAN_FAIL;
-        if(SUANPAN_SUCCESS != I.m_material->update_couple_trial_status(I.b2 * t_disp(t_dof) + I.b3 * t_disp(r_dof))) return SUANPAN_FAIL;
+        if(SUANPAN_SUCCESS != I.m_couple->update_trial_status(I.b2 * t_disp(t_dof) + I.b3 * t_disp(r_dof))) return SUANPAN_FAIL;
 
-        trial_stiffness(t_dof, t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stiffness() * I.b1 + I.weight * I.b2.t() * I.m_material->get_trial_couple_stiffness() * I.b2;
-        trial_stiffness(t_dof, r_dof) += I.weight * I.b2.t() * I.m_material->get_trial_couple_stiffness() * I.b3;
-        trial_stiffness(r_dof, t_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stiffness() * I.b2;
-        trial_stiffness(r_dof, r_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stiffness() * I.b3;
+        trial_stiffness(t_dof, t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stiffness() * I.b1 + I.weight * I.b2.t() * I.m_couple->get_trial_stiffness() * I.b2;
+        trial_stiffness(t_dof, r_dof) += I.weight * I.b2.t() * I.m_couple->get_trial_stiffness() * I.b3;
+        trial_stiffness(r_dof, t_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_stiffness() * I.b2;
+        trial_stiffness(r_dof, r_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_stiffness() * I.b3;
 
-        trial_resistance(t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stress() + I.weight * I.b2.t() * I.m_material->get_trial_couple_stress();
-        trial_resistance(r_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stress();
+        trial_resistance(t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stress() + I.weight * I.b2.t() * I.m_couple->get_trial_moment();
+        trial_resistance(r_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_moment();
     }
 
     return SUANPAN_SUCCESS;
@@ -180,19 +182,19 @@ int CSMT3::update_status() {
 
 int CSMT3::commit_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->commit_status() + I.m_material->clear_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->commit_status() + I.m_couple->commit_status();
     return code;
 }
 
 int CSMT3::clear_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->clear_status() + I.m_material->clear_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->clear_status() + I.m_couple->clear_status();
     return code;
 }
 
 int CSMT3::reset_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->reset_status() + I.m_material->reset_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->reset_status() + I.m_couple->reset_status();
     return code;
 }
 

--- a/Element/Membrane/CSM/CSMT3.h
+++ b/Element/Membrane/CSM/CSMT3.h
@@ -30,6 +30,7 @@
 #define CSMT3_H
 
 #include <Element/MaterialElement.h>
+#include <Material/CoupleMaterial.h>
 
 class CSMT3 final : public MaterialElement2D {
     static constexpr unsigned m_node = 3, m_dof = 3, m_size = m_dof * m_node;
@@ -41,6 +42,7 @@ class CSMT3 final : public MaterialElement2D {
         rowvec coor;
         double weight = 0.;
         unique_ptr<Material> m_material;
+        unique_ptr<IsotropicCouple> m_couple;
         mat b1, b2, b3;
         IntegrationPoint(rowvec&&, double, unique_ptr<Material>&&);
     };

--- a/Element/Membrane/CSM/CSMT6.cpp
+++ b/Element/Membrane/CSM/CSMT6.cpp
@@ -39,12 +39,14 @@ CSMT6::CSMT6(const unsigned T, uvec&& N, const unsigned M, const double TH, cons
 int CSMT6::initialize(const shared_ptr<DomainBase>& D) {
     auto& material_proto = D->get<Material>(material_tag(0));
 
-    if(!material_proto->is_support_couple()) {
-        suanpan_warning("Element {} is assigned with a material that does not support couple stress.\n", get_tag());
-        return SUANPAN_FAIL;
-    }
+    auto elastic_modulus = material_proto->get(Material::Parameter::ELASTIC);
+    auto poissons_ratio = material_proto->get(Material::Parameter::POISSON);
 
-    if(PlaneType::E == material_proto->get_plane_type()) suanpan::hacker(thickness) = 1.;
+    if(PlaneType::E == material_proto->get_plane_type()) {
+        suanpan::hacker(thickness) = 1.;
+        elastic_modulus /= 1. - poissons_ratio * poissons_ratio;
+        poissons_ratio /= 1. - poissons_ratio;
+    }
 
     mat ele_coor(m_node, m_node, fill::none);
     ele_coor.col(0).fill(1.);
@@ -76,8 +78,8 @@ int CSMT6::initialize(const shared_ptr<DomainBase>& D) {
 
         auto& c_pt = int_pt.back();
 
-        c_pt.m_material->set_characteristic_length(characteristic_length);
-        c_pt.m_material->initialize_couple(D);
+        c_pt.m_couple = std::make_unique<IsotropicCouple>(elastic_modulus, poissons_ratio, characteristic_length);
+        c_pt.m_couple->initialize(D);
 
         mat phi_s(2, t_size, fill::zeros), l_p(3, t_size, fill::zeros), j_p(1, t_size, fill::zeros), j_q(2, r_size, fill::zeros);
 
@@ -99,7 +101,7 @@ int CSMT6::initialize(const shared_ptr<DomainBase>& D) {
         const mat phi_a = shape::linear_stress(location(0), location(1));
         const mat phi_b = solve(c_pt.m_material->get_initial_stiffness(), phi_a);
 
-        E1 += c_pt.weight * phi_r.t() * c_pt.m_material->get_initial_couple_stiffness() * phi_r;
+        E1 += c_pt.weight * phi_r.t() * c_pt.m_couple->get_initial_stiffness() * phi_r;
         E2 += c_pt.weight * phi_b.t() * c_pt.m_material->get_initial_stiffness() * phi_b;
         H1 -= 2. * c_pt.weight * j_p.t() * j_s;
         H2 += c_pt.weight * l_p.t() * phi_a;
@@ -162,15 +164,15 @@ int CSMT6::update_status() {
 
     for(const auto& I : int_pt) {
         if(SUANPAN_SUCCESS != I.m_material->update_trial_status(I.b1 * t_disp(t_dof))) return SUANPAN_FAIL;
-        if(SUANPAN_SUCCESS != I.m_material->update_couple_trial_status(I.b2 * t_disp(t_dof) + I.b3 * t_disp(r_dof))) return SUANPAN_FAIL;
+        if(SUANPAN_SUCCESS != I.m_couple->update_trial_status(I.b2 * t_disp(t_dof) + I.b3 * t_disp(r_dof))) return SUANPAN_FAIL;
 
-        trial_stiffness(t_dof, t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stiffness() * I.b1 + I.weight * I.b2.t() * I.m_material->get_trial_couple_stiffness() * I.b2;
-        trial_stiffness(t_dof, r_dof) += I.weight * I.b2.t() * I.m_material->get_trial_couple_stiffness() * I.b3;
-        trial_stiffness(r_dof, t_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stiffness() * I.b2;
-        trial_stiffness(r_dof, r_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stiffness() * I.b3;
+        trial_stiffness(t_dof, t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stiffness() * I.b1 + I.weight * I.b2.t() * I.m_couple->get_trial_stiffness() * I.b2;
+        trial_stiffness(t_dof, r_dof) += I.weight * I.b2.t() * I.m_couple->get_trial_stiffness() * I.b3;
+        trial_stiffness(r_dof, t_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_stiffness() * I.b2;
+        trial_stiffness(r_dof, r_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_stiffness() * I.b3;
 
-        trial_resistance(t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stress() + I.weight * I.b2.t() * I.m_material->get_trial_couple_stress();
-        trial_resistance(r_dof) += I.weight * I.b3.t() * I.m_material->get_trial_couple_stress();
+        trial_resistance(t_dof) += I.weight * I.b1.t() * I.m_material->get_trial_stress() + I.weight * I.b2.t() * I.m_couple->get_trial_moment();
+        trial_resistance(r_dof) += I.weight * I.b3.t() * I.m_couple->get_trial_moment();
     }
 
     return SUANPAN_SUCCESS;
@@ -178,19 +180,19 @@ int CSMT6::update_status() {
 
 int CSMT6::commit_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->commit_status() + I.m_material->commit_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->commit_status() + I.m_couple->commit_status();
     return code;
 }
 
 int CSMT6::clear_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->clear_status() + I.m_material->clear_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->clear_status() + I.m_couple->clear_status();
     return code;
 }
 
 int CSMT6::reset_status() {
     auto code = 0;
-    for(const auto& I : int_pt) code += I.m_material->reset_status() + I.m_material->reset_couple_status();
+    for(const auto& I : int_pt) code += I.m_material->reset_status() + I.m_couple->reset_status();
     return code;
 }
 

--- a/Element/Membrane/CSM/CSMT6.h
+++ b/Element/Membrane/CSM/CSMT6.h
@@ -31,12 +31,14 @@
 #define CSMT6_H
 
 #include <Element/MaterialElement.h>
+#include <Material/CoupleMaterial.h>
 
 class CSMT6 final : public MaterialElement2D {
     struct IntegrationPoint final {
         vec coor;
         double weight;
         unique_ptr<Material> m_material;
+        unique_ptr<IsotropicCouple> m_couple;
         mat b1, b2, b3;
         IntegrationPoint(vec&&, double, unique_ptr<Material>&&);
     };

--- a/Material/CMakeLists.txt
+++ b/Material/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(MaterialOS)
 add_subdirectory(Special)
 
 target_sources(${PROJECT_NAME} PRIVATE
+        CoupleMaterial.cpp
         ExternalMaterial.cpp
         Material.cpp
         MaterialParser.cpp

--- a/Material/CoupleMaterial.cpp
+++ b/Material/CoupleMaterial.cpp
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (C) 2017-2026 Theodore Chang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+#include "CoupleMaterial.h"
+
+#include <Domain/DomainBase.h>
+
+void ConstantStiffness(CoupleMaterial* M) {
+    M->current_stiffness = mat(M->initial_stiffness.memptr(), M->initial_stiffness.n_rows, M->initial_stiffness.n_cols, false, true);
+    M->trial_stiffness = mat(M->initial_stiffness.memptr(), M->initial_stiffness.n_rows, M->initial_stiffness.n_cols, false, true);
+}
+
+CoupleMaterial::CoupleMaterial(const double L)
+    : DataCoupleMaterial{.characteristic_length = L} {}
+
+const vec& CoupleMaterial::get_trial_curvature() { return trial_curvature; }
+
+const vec& CoupleMaterial::get_trial_moment() { return trial_moment; }
+
+const mat& CoupleMaterial::get_trial_stiffness() { return trial_stiffness; }
+
+const vec& CoupleMaterial::get_current_curvature() { return current_curvature; }
+
+const vec& CoupleMaterial::get_current_moment() { return current_moment; }
+
+const mat& CoupleMaterial::get_current_stiffness() { return current_stiffness; }
+
+const mat& CoupleMaterial::get_initial_stiffness() const { return initial_stiffness; }
+
+int CoupleMaterial::update_incre_status(const double i_strain) { return update_incre_status(vec{i_strain}); }
+
+int CoupleMaterial::update_incre_status(const double i_strain, const double i_strain_rate) { return update_incre_status(vec{i_strain}, vec{i_strain_rate}); }
+
+int CoupleMaterial::update_incre_status(const double i_strain, const double i_strain_rate, const double i_strain_acc) { return update_incre_status(vec{i_strain}, vec{i_strain_rate}, vec{i_strain_acc}); }
+
+int CoupleMaterial::update_trial_status(const double t_strain) { return update_trial_status(vec{t_strain}); }
+
+int CoupleMaterial::update_trial_status(const double t_strain, const double t_strain_rate) { return update_trial_status(vec{t_strain}, vec{t_strain_rate}); }
+
+int CoupleMaterial::update_trial_status(const double t_strain, const double t_strain_rate, const double t_strain_acc) { return update_trial_status(vec{t_strain}, vec{t_strain_rate}, vec{t_strain_acc}); }
+
+int CoupleMaterial::update_incre_status(const vec& i_curvature) { return update_trial_status(current_curvature + i_curvature); }
+
+int CoupleMaterial::update_incre_status(const vec& i_curvature, const vec&) { return update_trial_status(current_curvature + i_curvature); }
+
+int CoupleMaterial::update_incre_status(const vec& i_curvature, const vec&, const vec&) { return update_trial_status(current_curvature + i_curvature); }
+
+int CoupleMaterial::update_trial_status(const vec& t_curvature) {
+    trial_moment = trial_stiffness * (trial_curvature = t_curvature);
+    return SUANPAN_SUCCESS;
+}
+
+int CoupleMaterial::update_trial_status(const vec& t_curvature, const vec&) { return update_trial_status(t_curvature); }
+
+int CoupleMaterial::update_trial_status(const vec& t_curvature, const vec&, const vec&) { return update_trial_status(t_curvature); }
+
+int CoupleMaterial::clear_status() {
+    if(!current_curvature.is_empty()) current_curvature.zeros();
+    if(!current_moment.is_empty()) current_moment.zeros();
+
+    if(!trial_curvature.is_empty()) trial_curvature.zeros();
+    if(!trial_moment.is_empty()) trial_moment.zeros();
+
+    if(!initial_stiffness.is_empty()) trial_stiffness = current_stiffness = initial_stiffness;
+
+    return SUANPAN_SUCCESS;
+}
+
+int CoupleMaterial::commit_status() {
+    if(!trial_curvature.is_empty()) current_curvature = trial_curvature;
+    if(!trial_moment.is_empty()) current_moment = trial_moment;
+    if(!trial_stiffness.is_empty()) current_stiffness = trial_stiffness;
+
+    return SUANPAN_SUCCESS;
+}
+
+int CoupleMaterial::reset_status() {
+    if(!trial_curvature.is_empty()) trial_curvature = current_curvature;
+    if(!trial_moment.is_empty()) trial_moment = current_moment;
+    if(!trial_stiffness.is_empty()) trial_stiffness = current_stiffness;
+
+    return SUANPAN_SUCCESS;
+}
+
+IsotropicCouple::IsotropicCouple(const double E, const double V, const double L)
+    : CoupleMaterial(L)
+    , elastic_modulus(E)
+    , poissons_ratio(V) {}
+
+void IsotropicCouple::initialize(const shared_ptr<DomainBase>&) {
+    if(characteristic_length < 0.) {
+        access::rw(characteristic_length) = 1.;
+        suanpan_warning("Characteristic length is set to unity.\n");
+    }
+
+    initial_stiffness = 2. * characteristic_length * characteristic_length * elastic_modulus / (1. + poissons_ratio) * eye(2, 2);
+
+    trial_curvature = current_curvature.zeros(2);
+    trial_moment = current_moment.zeros(2);
+
+    ConstantStiffness(this);
+}

--- a/Material/CoupleMaterial.h
+++ b/Material/CoupleMaterial.h
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (C) 2017-2026 Theodore Chang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+/**
+ * @class CoupleMaterial
+ * @brief A CoupleMaterial abstract base class.
+ * @author tlc
+ * @date 14/08/2026
+ * @version 0.1.0
+ * @file CoupleMaterial.h
+ * @addtogroup Material
+ * @{
+ */
+
+#ifndef COUPLEMATERIAL_H
+#define COUPLEMATERIAL_H
+
+#include <suanPan.h>
+
+class DomainBase;
+
+struct DataCoupleMaterial {
+    const double characteristic_length;
+
+    vec current_curvature{};
+    vec current_moment{};
+
+    vec trial_curvature{};
+    vec trial_moment{};
+
+    vec incre_curvature{};
+    vec incre_moment{};
+
+    mat initial_stiffness{};
+    mat current_stiffness{};
+    mat trial_stiffness{};
+};
+
+class CoupleMaterial : protected DataCoupleMaterial {
+    friend void ConstantStiffness(CoupleMaterial*);
+
+public:
+    explicit CoupleMaterial(double);
+    virtual ~CoupleMaterial() = default;
+
+    [[nodiscard]] virtual std::unique_ptr<CoupleMaterial> unique_copy() const = 0;
+
+    virtual void initialize(const shared_ptr<DomainBase>&) {}
+
+    const vec& get_trial_curvature();
+    const vec& get_trial_moment();
+    const mat& get_trial_stiffness();
+
+    const vec& get_current_curvature();
+    const vec& get_current_moment();
+    const mat& get_current_stiffness();
+
+    [[nodiscard]] const mat& get_initial_stiffness() const;
+
+    int update_incre_status(double);
+    int update_incre_status(double, double);
+    int update_incre_status(double, double, double);
+    int update_trial_status(double);
+    int update_trial_status(double, double);
+    int update_trial_status(double, double, double);
+
+    int update_incre_status(const vec&);
+    int update_incre_status(const vec&, const vec&);
+    int update_incre_status(const vec&, const vec&, const vec&);
+    int update_trial_status(const vec&);
+    int update_trial_status(const vec&, const vec&);
+    int update_trial_status(const vec&, const vec&, const vec&);
+
+    int clear_status();
+    int commit_status();
+    int reset_status();
+};
+
+class IsotropicCouple final : public CoupleMaterial {
+    const double elastic_modulus, poissons_ratio;
+
+public:
+    IsotropicCouple(double, double, double);
+
+    [[nodiscard]] std::unique_ptr<CoupleMaterial> unique_copy() const override { return std::make_unique<IsotropicCouple>(*this); }
+
+    void initialize(const shared_ptr<DomainBase>&) override;
+};
+
+#endif
+
+//! @}

--- a/Material/Material.cpp
+++ b/Material/Material.cpp
@@ -22,7 +22,6 @@
 
 Material::Material(const unsigned T, const MaterialType MT, const double D)
     : DataMaterial{.density = fabs(D), .material_type = MT}
-    , DataCoupleMaterial{}
     , CopyableTag(T) {}
 
 double Material::get_density() const { return density; }
@@ -49,8 +48,6 @@ int Material::initialize_base(const shared_ptr<DomainBase>&) {
     return SUANPAN_SUCCESS;
 }
 
-void Material::initialize_couple(const shared_ptr<DomainBase>&) {}
-
 void Material::initialize_history(const unsigned size) {
     if(static_cast<uword>(size) > initial_history.size()) initial_history.resize(size);
 
@@ -63,17 +60,9 @@ void Material::set_initialized(const bool F) const { access::rw(initialized) = F
 
 void Material::set_symmetric(const bool F) const { access::rw(symmetric) = F; }
 
-void Material::set_support_couple(const bool F) const { access::rw(support_couple) = F; }
-
 bool Material::is_initialized() const { return initialized; }
 
 bool Material::is_symmetric() const { return symmetric; }
-
-bool Material::is_support_couple() const { return support_couple; }
-
-void Material::set_characteristic_length(const double L) const { access::rw(characteristic_length) = std::max(datum::eps, L); }
-
-double Material::get_characteristic_length() const { return characteristic_length; }
 
 double Material::get(Parameter) const { return 0.; }
 
@@ -123,20 +112,6 @@ const mat& Material::get_initial_damping() const { return initial_damping; }
 
 const mat& Material::get_initial_inertial() const { return initial_inertial; }
 
-const vec& Material::get_trial_curvature() { return trial_curvature; }
-
-const vec& Material::get_trial_couple_stress() { return trial_couple_stress; }
-
-const mat& Material::get_trial_couple_stiffness() { return trial_couple_stiffness; }
-
-const vec& Material::get_current_curvature() { return current_curvature; }
-
-const vec& Material::get_current_couple_stress() { return current_couple_stress; }
-
-const mat& Material::get_current_couple_stiffness() { return current_couple_stiffness; }
-
-const mat& Material::get_initial_couple_stiffness() const { return initial_couple_stiffness; }
-
 unique_ptr<Material> Material::unique_copy() { throw std::invalid_argument("hidden method unique_copy() called"); }
 
 int Material::update_incre_status(const double i_strain) { return update_incre_status(vec{i_strain}); }
@@ -170,33 +145,6 @@ int Material::update_trial_status(const vec& t_strain, const vec& t_strain_rate,
     return update_trial_status(t_strain);
 }
 
-int Material::update_couple_incre_status(const double i_strain) { return update_couple_incre_status(vec{i_strain}); }
-
-int Material::update_couple_incre_status(const double i_strain, const double i_strain_rate) { return update_couple_incre_status(vec{i_strain}, vec{i_strain_rate}); }
-
-int Material::update_couple_incre_status(const double i_strain, const double i_strain_rate, const double i_strain_acc) { return update_couple_incre_status(vec{i_strain}, vec{i_strain_rate}, vec{i_strain_acc}); }
-
-int Material::update_couple_trial_status(const double t_strain) { return update_couple_trial_status(vec{t_strain}); }
-
-int Material::update_couple_trial_status(const double t_strain, const double t_strain_rate) { return update_couple_trial_status(vec{t_strain}, vec{t_strain_rate}); }
-
-int Material::update_couple_trial_status(const double t_strain, const double t_strain_rate, const double t_strain_acc) { return update_couple_trial_status(vec{t_strain}, vec{t_strain_rate}, vec{t_strain_acc}); }
-
-int Material::update_couple_incre_status(const vec& i_curvature) { return update_couple_trial_status(current_curvature + i_curvature); }
-
-int Material::update_couple_incre_status(const vec& i_curvature, const vec&) { return update_couple_trial_status(current_curvature + i_curvature); }
-
-int Material::update_couple_incre_status(const vec& i_curvature, const vec&, const vec&) { return update_couple_trial_status(current_curvature + i_curvature); }
-
-int Material::update_couple_trial_status(const vec& t_curvature) {
-    trial_couple_stress = trial_couple_stiffness * (trial_curvature = t_curvature);
-    return SUANPAN_SUCCESS;
-}
-
-int Material::update_couple_trial_status(const vec& t_curvature, const vec&) { return update_couple_trial_status(t_curvature); }
-
-int Material::update_couple_trial_status(const vec& t_curvature, const vec&, const vec&) { return update_couple_trial_status(t_curvature); }
-
 int Material::clear_status() {
     if(!current_strain.is_empty()) current_strain.zeros();
     if(!current_strain_rate.is_empty()) current_strain_rate.zeros();
@@ -218,14 +166,6 @@ int Material::clear_status() {
     if(!initial_damping.is_empty()) trial_damping = current_damping = initial_damping;
     if(!initial_inertial.is_empty()) trial_inertial = current_inertial = initial_inertial;
 
-    if(!current_curvature.is_empty()) current_curvature.zeros();
-    if(!current_couple_stress.is_empty()) current_couple_stress.zeros();
-
-    if(!trial_curvature.is_empty()) trial_curvature.zeros();
-    if(!trial_couple_stress.is_empty()) trial_couple_stress.zeros();
-
-    if(!initial_couple_stiffness.is_empty()) trial_couple_stiffness = current_couple_stiffness = initial_couple_stiffness;
-
     return SUANPAN_SUCCESS;
 }
 
@@ -239,10 +179,6 @@ int Material::commit_status() {
     if(!trial_damping.is_empty()) current_damping = trial_damping;
     if(!trial_inertial.is_empty()) current_inertial = trial_inertial;
 
-    if(!trial_curvature.is_empty()) current_curvature = trial_curvature;
-    if(!trial_couple_stress.is_empty()) current_couple_stress = trial_couple_stress;
-    if(!trial_couple_stiffness.is_empty()) current_couple_stiffness = trial_couple_stiffness;
-
     return SUANPAN_SUCCESS;
 }
 
@@ -255,38 +191,6 @@ int Material::reset_status() {
     if(!trial_stiffness.is_empty()) trial_stiffness = current_stiffness;
     if(!trial_damping.is_empty()) trial_damping = current_damping;
     if(!trial_inertial.is_empty()) trial_inertial = current_inertial;
-
-    if(!trial_curvature.is_empty()) trial_curvature = current_curvature;
-    if(!trial_couple_stress.is_empty()) trial_couple_stress = current_couple_stress;
-    if(!trial_couple_stiffness.is_empty()) trial_couple_stiffness = current_couple_stiffness;
-
-    return SUANPAN_SUCCESS;
-}
-
-int Material::clear_couple_status() {
-    if(!current_curvature.is_empty()) current_curvature.zeros();
-    if(!current_couple_stress.is_empty()) current_couple_stress.zeros();
-
-    if(!trial_curvature.is_empty()) trial_curvature.zeros();
-    if(!trial_couple_stress.is_empty()) trial_couple_stress.zeros();
-
-    if(!initial_couple_stiffness.is_empty()) trial_couple_stiffness = current_couple_stiffness = initial_couple_stiffness;
-
-    return SUANPAN_SUCCESS;
-}
-
-int Material::commit_couple_status() {
-    if(!trial_curvature.is_empty()) current_curvature = trial_curvature;
-    if(!trial_couple_stress.is_empty()) current_couple_stress = trial_couple_stress;
-    if(!trial_couple_stiffness.is_empty()) current_couple_stiffness = trial_couple_stiffness;
-
-    return SUANPAN_SUCCESS;
-}
-
-int Material::reset_couple_status() {
-    if(!trial_curvature.is_empty()) trial_curvature = current_curvature;
-    if(!trial_couple_stress.is_empty()) trial_couple_stress = current_couple_stress;
-    if(!trial_couple_stiffness.is_empty()) trial_couple_stiffness = current_couple_stiffness;
 
     return SUANPAN_SUCCESS;
 }
@@ -317,12 +221,7 @@ void ConstantInertial(DataMaterial* M) {
     M->trial_inertial = mat(M->initial_inertial.memptr(), M->initial_inertial.n_rows, M->initial_inertial.n_cols, false, true);
 }
 
-void ConstantCoupleStiffness(DataCoupleMaterial* M) {
-    M->current_couple_stiffness = mat(M->initial_couple_stiffness.memptr(), M->initial_couple_stiffness.n_rows, M->initial_couple_stiffness.n_cols, false, true);
-    M->trial_couple_stiffness = mat(M->initial_couple_stiffness.memptr(), M->initial_couple_stiffness.n_rows, M->initial_couple_stiffness.n_cols, false, true);
-}
-
-void PureWrapper(Material* M) {
+void PureWrapper(DataMaterial* M) {
     M->current_strain.reset();
     M->current_strain_rate.reset();
     M->current_strain_acc.reset();
@@ -353,19 +252,6 @@ void PureWrapper(Material* M) {
     M->initial_inertial.reset();
     M->current_inertial.reset();
     M->trial_inertial.reset();
-
-    M->current_curvature.reset();
-    M->current_couple_stress.reset();
-
-    M->trial_curvature.reset();
-    M->trial_couple_stress.reset();
-
-    M->incre_curvature.reset();
-    M->incre_couple_stress.reset();
-
-    M->initial_couple_stiffness.reset();
-    M->current_couple_stiffness.reset();
-    M->trial_couple_stiffness.reset();
 }
 
 unique_ptr<Material> suanpan::unique_copy(const shared_ptr<Material>& P) { return nullptr == P ? nullptr : P->unique_copy(); }

--- a/Material/Material.cpp
+++ b/Material/Material.cpp
@@ -20,6 +20,54 @@
 #include <Domain/DomainBase.h>
 #include <Recorder/OutputType.h>
 
+void ConstantStiffness(DataMaterial* M) {
+    M->current_stiffness = mat(M->initial_stiffness.memptr(), M->initial_stiffness.n_rows, M->initial_stiffness.n_cols, false, true);
+    M->trial_stiffness = mat(M->initial_stiffness.memptr(), M->initial_stiffness.n_rows, M->initial_stiffness.n_cols, false, true);
+}
+
+void ConstantDamping(DataMaterial* M) {
+    M->current_damping = mat(M->initial_damping.memptr(), M->initial_damping.n_rows, M->initial_damping.n_cols, false, true);
+    M->trial_damping = mat(M->initial_damping.memptr(), M->initial_damping.n_rows, M->initial_damping.n_cols, false, true);
+}
+
+void ConstantInertial(DataMaterial* M) {
+    M->current_inertial = mat(M->initial_inertial.memptr(), M->initial_inertial.n_rows, M->initial_inertial.n_cols, false, true);
+    M->trial_inertial = mat(M->initial_inertial.memptr(), M->initial_inertial.n_rows, M->initial_inertial.n_cols, false, true);
+}
+
+void PureWrapper(DataMaterial* M) {
+    M->current_strain.reset();
+    M->current_strain_rate.reset();
+    M->current_strain_acc.reset();
+    M->current_stress.reset();
+
+    M->trial_strain.reset();
+    M->trial_strain_rate.reset();
+    M->trial_strain_acc.reset();
+    M->trial_stress.reset();
+
+    M->incre_strain.reset();
+    M->incre_strain_rate.reset();
+    M->incre_strain_acc.reset();
+    M->incre_stress.reset();
+
+    M->initial_history.reset();
+    M->current_history.reset();
+    M->trial_history.reset();
+
+    M->initial_stiffness.reset();
+    M->current_stiffness.reset();
+    M->trial_stiffness.reset();
+
+    M->initial_damping.reset();
+    M->current_damping.reset();
+    M->trial_damping.reset();
+
+    M->initial_inertial.reset();
+    M->current_inertial.reset();
+    M->trial_inertial.reset();
+}
+
 Material::Material(const unsigned T, const MaterialType MT, const double D)
     : DataMaterial{.density = fabs(D), .material_type = MT}
     , CopyableTag(T) {}
@@ -204,54 +252,6 @@ std::vector<vec> Material::record(const OutputType P) const {
     if(P == OutputType::YF) return {vec{any(current_history != 0.) ? 1. : 0.}};
 
     return {};
-}
-
-void ConstantStiffness(DataMaterial* M) {
-    M->current_stiffness = mat(M->initial_stiffness.memptr(), M->initial_stiffness.n_rows, M->initial_stiffness.n_cols, false, true);
-    M->trial_stiffness = mat(M->initial_stiffness.memptr(), M->initial_stiffness.n_rows, M->initial_stiffness.n_cols, false, true);
-}
-
-void ConstantDamping(DataMaterial* M) {
-    M->current_damping = mat(M->initial_damping.memptr(), M->initial_damping.n_rows, M->initial_damping.n_cols, false, true);
-    M->trial_damping = mat(M->initial_damping.memptr(), M->initial_damping.n_rows, M->initial_damping.n_cols, false, true);
-}
-
-void ConstantInertial(DataMaterial* M) {
-    M->current_inertial = mat(M->initial_inertial.memptr(), M->initial_inertial.n_rows, M->initial_inertial.n_cols, false, true);
-    M->trial_inertial = mat(M->initial_inertial.memptr(), M->initial_inertial.n_rows, M->initial_inertial.n_cols, false, true);
-}
-
-void PureWrapper(DataMaterial* M) {
-    M->current_strain.reset();
-    M->current_strain_rate.reset();
-    M->current_strain_acc.reset();
-    M->current_stress.reset();
-
-    M->trial_strain.reset();
-    M->trial_strain_rate.reset();
-    M->trial_strain_acc.reset();
-    M->trial_stress.reset();
-
-    M->incre_strain.reset();
-    M->incre_strain_rate.reset();
-    M->incre_strain_acc.reset();
-    M->incre_stress.reset();
-
-    M->initial_history.reset();
-    M->current_history.reset();
-    M->trial_history.reset();
-
-    M->initial_stiffness.reset();
-    M->current_stiffness.reset();
-    M->trial_stiffness.reset();
-
-    M->initial_damping.reset();
-    M->current_damping.reset();
-    M->trial_damping.reset();
-
-    M->initial_inertial.reset();
-    M->current_inertial.reset();
-    M->trial_inertial.reset();
 }
 
 unique_ptr<Material> suanpan::unique_copy(const shared_ptr<Material>& P) { return nullptr == P ? nullptr : P->unique_copy(); }

--- a/Material/Material.h
+++ b/Material/Material.h
@@ -59,6 +59,7 @@ struct DataMaterial {
     const PlaneType plane_type = PlaneType::N;
 
     const double tolerance = 1E-14;
+    const double characteristic_length = 1.;
 
     vec current_strain{}; // current status
     vec trial_strain{};   // trial status
@@ -137,6 +138,8 @@ public:
     void set_symmetric(bool) const;
     [[nodiscard]] bool is_initialized() const;
     [[nodiscard]] bool is_symmetric() const;
+
+    void set_characteristic_length(const double L) const { access::rw(characteristic_length) = std::max(datum::eps, std::fabs(L)); }
 
     [[nodiscard]] virtual double get(Parameter) const;
 

--- a/Material/Material.h
+++ b/Material/Material.h
@@ -53,28 +53,12 @@ enum class PlaneType : unsigned {
 class DomainBase;
 enum class OutputType;
 
-struct DataCoupleMaterial {
-    vec current_curvature{};
-    vec current_couple_stress{};
-
-    vec trial_curvature{};
-    vec trial_couple_stress{};
-
-    vec incre_curvature{};
-    vec incre_couple_stress{};
-
-    mat initial_couple_stiffness{}; // stiffness matrix
-    mat current_couple_stiffness{}; // stiffness matrix
-    mat trial_couple_stiffness{};   // stiffness matrix
-};
-
 struct DataMaterial {
     const double density = 0.;
     const MaterialType material_type = MaterialType::D0;
     const PlaneType plane_type = PlaneType::N;
 
     const double tolerance = 1E-14;
-    const double characteristic_length = -1.;
 
     vec current_strain{}; // current status
     vec trial_strain{};   // trial status
@@ -113,16 +97,14 @@ struct DataMaterial {
     mat trial_inertial{};   // inertial matrix
 };
 
-class Material : protected DataMaterial, protected DataCoupleMaterial, public CopyableTag {
+class Material : protected DataMaterial, public CopyableTag {
     const bool initialized = false;
     const bool symmetric = false;
-    const bool support_couple = false; // indicate if the material supports couple stress theory
 
     friend void ConstantStiffness(DataMaterial*);
     friend void ConstantDamping(DataMaterial*);
     friend void ConstantInertial(DataMaterial*);
-    friend void ConstantCoupleStiffness(DataCoupleMaterial*);
-    friend void PureWrapper(Material*);
+    friend void PureWrapper(DataMaterial*);
 
 public:
     enum class Parameter {
@@ -147,20 +129,14 @@ public:
     int initialize_base(const shared_ptr<DomainBase>&);
 
     virtual int initialize(const shared_ptr<DomainBase>&) = 0;
-    virtual void initialize_couple(const shared_ptr<DomainBase>&);
 
     virtual void initialize_history(unsigned);
     virtual void set_initial_history(const vec&);
 
     void set_initialized(bool) const;
     void set_symmetric(bool) const;
-    void set_support_couple(bool) const;
     [[nodiscard]] bool is_initialized() const;
     [[nodiscard]] bool is_symmetric() const;
-    [[nodiscard]] bool is_support_couple() const;
-
-    void set_characteristic_length(double) const;
-    [[nodiscard]] double get_characteristic_length() const;
 
     [[nodiscard]] virtual double get(Parameter) const;
 
@@ -187,16 +163,6 @@ public:
     [[nodiscard]] virtual const mat& get_initial_damping() const;
     [[nodiscard]] virtual const mat& get_initial_inertial() const;
 
-    virtual const vec& get_trial_curvature();
-    virtual const vec& get_trial_couple_stress();
-    virtual const mat& get_trial_couple_stiffness();
-
-    virtual const vec& get_current_curvature();
-    virtual const vec& get_current_couple_stress();
-    virtual const mat& get_current_couple_stiffness();
-
-    [[nodiscard]] virtual const mat& get_initial_couple_stiffness() const;
-
     virtual unique_ptr<Material> unique_copy() = 0;
 
     int update_incre_status(double);
@@ -213,27 +179,9 @@ public:
     virtual int update_trial_status(const vec&, const vec&);
     virtual int update_trial_status(const vec&, const vec&, const vec&);
 
-    int update_couple_incre_status(double);
-    int update_couple_incre_status(double, double);
-    int update_couple_incre_status(double, double, double);
-    int update_couple_trial_status(double);
-    int update_couple_trial_status(double, double);
-    int update_couple_trial_status(double, double, double);
-
-    virtual int update_couple_incre_status(const vec&);
-    virtual int update_couple_incre_status(const vec&, const vec&);
-    virtual int update_couple_incre_status(const vec&, const vec&, const vec&);
-    virtual int update_couple_trial_status(const vec&);
-    virtual int update_couple_trial_status(const vec&, const vec&);
-    virtual int update_couple_trial_status(const vec&, const vec&, const vec&);
-
     virtual int clear_status() = 0;
     virtual int commit_status() = 0;
     virtual int reset_status() = 0;
-
-    virtual int clear_couple_status();
-    virtual int commit_couple_status();
-    virtual int reset_couple_status();
 
     [[nodiscard]] virtual std::vector<vec> record(OutputType) const;
 

--- a/Material/Material1D/Concrete/NonlinearK4.cpp
+++ b/Material/Material1D/Concrete/NonlinearK4.cpp
@@ -110,7 +110,7 @@ double NonlinearK4::objective_scale(const double a, const double zeta) const {
     if(!objective_damage) return zeta;
 
     const auto ratio = a / zeta;
-    return 2. * a / (std::sqrt(1. + 4. / get_characteristic_length() * (ratio * ratio + ratio)) - 1.);
+    return 2. * a / (std::sqrt(1. + 4. / characteristic_length * (ratio * ratio + ratio)) - 1.);
 }
 
 NonlinearK4::NonlinearK4(const unsigned T, const double E, const double H, const double R, const bool FD, const bool FC, const bool OD)

--- a/Material/Material1D/Concrete/NonlinearK4.h
+++ b/Material/Material1D/Concrete/NonlinearK4.h
@@ -18,6 +18,8 @@
  * @class NonlinearK4
  * @brief A ConcreteK4 material class.
  *
+ * doi:10.1061/(ASCE)ST.1943-541X.0002592
+ *
  * @author tlc
  * @date 05/09/2023
  * @version 0.1.0

--- a/Material/Material2D/Elastic/Elastic2D.cpp
+++ b/Material/Material2D/Elastic/Elastic2D.cpp
@@ -23,7 +23,7 @@
 Elastic2D::Elastic2D(const unsigned T, const double E, const double P, const double R, const PlaneType PT)
     : Material2D(T, PT, R)
     , elastic_modulus(E)
-    , poissons_ratio(P) { set_support_couple(true); }
+    , poissons_ratio(P) {}
 
 int Elastic2D::initialize(const shared_ptr<DomainBase>&) {
     const auto EE = plane_type == PlaneType::S ? elastic_modulus : elastic_modulus / (1. - poissons_ratio * poissons_ratio);
@@ -38,20 +38,6 @@ int Elastic2D::initialize(const shared_ptr<DomainBase>&) {
     ConstantStiffness(this);
 
     return SUANPAN_SUCCESS;
-}
-
-void Elastic2D::initialize_couple(const shared_ptr<DomainBase>&) {
-    if(characteristic_length < 0.) {
-        access::rw(characteristic_length) = 1.;
-        suanpan_warning("Characteristic length is set to unity.\n");
-    }
-
-    initial_couple_stiffness = 2. * characteristic_length * characteristic_length * elastic_modulus / (1. + poissons_ratio) * eye(2, 2);
-
-    trial_curvature = current_curvature.zeros(2);
-    trial_couple_stress = current_couple_stress.zeros(2);
-
-    ConstantCoupleStiffness(this);
 }
 
 double Elastic2D::get(const Parameter P) const { return MaterialProperty(elastic_modulus, poissons_ratio)(P); }

--- a/Material/Material2D/Elastic/Elastic2D.h
+++ b/Material/Material2D/Elastic/Elastic2D.h
@@ -52,7 +52,6 @@ public:
     );
 
     int initialize(const shared_ptr<DomainBase>&) override;
-    void initialize_couple(const shared_ptr<DomainBase>&) override;
 
     [[nodiscard]] double get(Parameter) const override;
 


### PR DESCRIPTION
Introduce the CoupleMaterial class to handle material behavior related to couple stress. Streamline the Material class by removing couple-related functionality and simplify the Elastic2D class. Refactor CSMQ and CSMQ4 classes to utilize IsotropicCouple for couple stress handling.