### PR TITLE
Add NonlocalBilinearJ2 material model implementation

### DIFF
--- a/Example/Material/NonlocalBilinearJ2.supan
+++ b/Example/Material/NonlocalBilinearJ2.supan
@@ -1,0 +1,43 @@
+# A TEST MODEL FOR NONLOCALBILINEARJ2 MATERIAL
+
+node 1 .5 -.5 -.5
+node 2 .5 .5 -.5
+node 3 -.5 .5 -.5
+node 4 -.5 -.5 -.5
+node 5 .5 -.5 .5
+node 6 .5 .5 .5
+node 7 -.5 .5 .5
+node 8 -.5 -.5 .5
+
+material NonlocalBilinearJ2 1 1e4 .2 200 1e-1 5. .02
+
+element NonlocalC3D8 1 1 2 3 4 5 6 7 8 1 1.
+
+fix2 1 1 3 4 7 8
+fix2 2 2 1 4 5 8
+fix2 3 3 1 2 3 4
+
+amplitude Sine 1 2 1
+
+displacement 1 1 .4 3 5 6 7 8
+
+hdf5recorder 1 Node RF3 7
+hdf5recorder 2 Node U3 7
+hdf5recorder 3 Element Nonlocal 1
+
+step static 1
+set fixed_step_size 1
+set ini_step_size 1E-2
+set symm_mat 0
+
+converger AbsIncreDisp 1 1E-11 10 1
+
+analyze
+
+peek node 1 2 3 4 5 6 7 8
+
+peek element 1
+
+reset
+clear
+exit

--- a/Material/Material3D/CMakeLists.txt
+++ b/Material/Material3D/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME} PRIVATE
         Elastic/OrthotropicElastic3D.cpp
         Elastic/Yeoh.cpp
         Material3D.cpp
+        Nonlocal/NonlocalBilinearJ2.cpp
         Nonlocal/NonlocalIsotropicElastic3D.cpp
         Orthotropic/CustomOrthotropic.cpp
         Orthotropic/NonlinearOrthotropic.cpp

--- a/Material/Material3D/Material3D
+++ b/Material/Material3D/Material3D
@@ -22,6 +22,7 @@
 #include "Elastic/NLE3D01.h"
 #include "Elastic/OrthotropicElastic3D.h"
 #include "Elastic/Yeoh.h"
+#include "Nonlocal/NonlocalBilinearJ2.h"
 #include "Nonlocal/NonlocalIsotropicElastic3D.h"
 #include "Orthotropic/BilinearOrthotropic.h"
 #include "Orthotropic/CustomOrthotropic.h"

--- a/Material/Material3D/Nonlocal/NonlocalBilinearJ2.cpp
+++ b/Material/Material3D/Nonlocal/NonlocalBilinearJ2.cpp
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (C) 2017-2026 Theodore Chang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+#include "NonlocalBilinearJ2.h"
+
+#include <Toolbox/tensor.h>
+
+constexpr double NonlocalBilinearJ2::two_third = 2. / 3.;
+const double NonlocalBilinearJ2::root_two_third = std::sqrt(two_third);
+const mat NonlocalBilinearJ2::unit_dev_tensor = tensor::unit_deviatoric_tensor4();
+const uvec NonlocalBilinearJ2::u_dof{0, 1, 2, 3, 4, 5};
+const uvec NonlocalBilinearJ2::d_dof{6};
+
+NonlocalBilinearJ2::NonlocalBilinearJ2(const unsigned T, const double E, const double V, const double Y, const double ER, const double H, const double B, const double R)
+    : DataNonlocalBilinearJ2{.elastic_modulus = std::fabs(E), .poissons_ratio = V, .yield_stress = std::fabs(Y), .evolution_rate = std::fabs(ER), .hardening_ratio = H, .beta = std::clamp(B, 0., 1.)}
+    , Material3D(T, R) {}
+
+int NonlocalBilinearJ2::initialize(const shared_ptr<DomainBase>&) {
+    trial_stiffness = current_stiffness = initial_stiffness = tensor::isotropic_stiffness(elastic_modulus, poissons_ratio, nonlocal_size());
+
+    initialize_history(13);
+
+    return SUANPAN_SUCCESS;
+}
+
+unique_ptr<Material> NonlocalBilinearJ2::unique_copy() { return std::make_unique<NonlocalBilinearJ2>(*this); }
+
+double NonlocalBilinearJ2::get(const Parameter P) const { return MaterialProperty(elastic_modulus, poissons_ratio)(P); }
+
+int NonlocalBilinearJ2::update_trial_status(const vec& t_strain) {
+    incre_strain = (trial_strain = t_strain) - current_strain;
+
+    if(norm(incre_strain) <= datum::eps) return SUANPAN_SUCCESS;
+
+    trial_history = current_history;
+    auto& eqv_plastic_strain = trial_history(0);
+    vec back_stress(&trial_history(1), 6, false, true);
+    vec plastic_strain(&trial_history(7), 6, false, true);
+
+    trial_stiffness = initial_stiffness;
+    trial_stress.head(6) = trial_stiffness(u_dof, u_dof) * (trial_strain.head(6) - plastic_strain);
+
+    const vec shifted_stress = tensor::dev(trial_stress.head(6)) - back_stress;
+
+    const auto norm_shifted_stress = tensor::stress::norm(shifted_stress);
+
+    const auto yield_surf = yield_stress + isotropic_modulus * eqv_plastic_strain;
+
+    if(const auto yield_func = norm_shifted_stress - root_two_third * std::max(yield_surf, 0.); yield_func > 0.) {
+        const auto tmp_a = double_shear + two_third * (kinematic_modulus + (yield_surf > 0. ? isotropic_modulus : 0.));
+        const auto gamma = yield_func / tmp_a;
+
+        auto tmp_b = double_shear * gamma / norm_shifted_stress;
+        trial_stress.head(6) -= tmp_b * shifted_stress;
+
+        back_stress += two_third * kinematic_modulus * gamma / norm_shifted_stress * shifted_stress;
+        eqv_plastic_strain += root_two_third * gamma;
+
+        tmp_b *= double_shear;
+        trial_stiffness(u_dof, u_dof) += (tmp_b - square_double_shear / tmp_a) / norm_shifted_stress / norm_shifted_stress * shifted_stress * shifted_stress.t() - tmp_b * unit_dev_tensor;
+    }
+
+    return SUANPAN_SUCCESS;
+}
+
+int NonlocalBilinearJ2::clear_status() {
+    current_strain.zeros();
+    current_stress.zeros();
+    current_history = initial_history;
+    current_stiffness = initial_stiffness;
+    return reset_status();
+}
+
+int NonlocalBilinearJ2::commit_status() {
+    current_strain = trial_strain;
+    current_stress = trial_stress;
+    current_history = trial_history;
+    current_stiffness = trial_stiffness;
+    return SUANPAN_SUCCESS;
+}
+
+int NonlocalBilinearJ2::reset_status() {
+    trial_strain = current_strain;
+    trial_stress = current_stress;
+    trial_history = current_history;
+    trial_stiffness = current_stiffness;
+    return SUANPAN_SUCCESS;
+}
+
+void NonlocalBilinearJ2::print() {
+    suanpan_info("A 3D bilinear hardening model.\n");
+}

--- a/Material/Material3D/Nonlocal/NonlocalBilinearJ2.cpp
+++ b/Material/Material3D/Nonlocal/NonlocalBilinearJ2.cpp
@@ -22,11 +22,11 @@
 constexpr double NonlocalBilinearJ2::two_third = 2. / 3.;
 const double NonlocalBilinearJ2::root_two_third = std::sqrt(two_third);
 const mat NonlocalBilinearJ2::unit_dev_tensor = tensor::unit_deviatoric_tensor4();
-const uvec NonlocalBilinearJ2::u_dof{0, 1, 2, 3, 4, 5};
-const uvec NonlocalBilinearJ2::d_dof{6};
+const uvec NonlocalBilinearJ2::UD{0, 1, 2, 3, 4, 5};
+const uvec NonlocalBilinearJ2::DD{6};
 
-NonlocalBilinearJ2::NonlocalBilinearJ2(const unsigned T, const double E, const double V, const double Y, const double ER, const double H, const double B, const double R)
-    : DataNonlocalBilinearJ2{.elastic_modulus = std::fabs(E), .poissons_ratio = V, .yield_stress = std::fabs(Y), .evolution_rate = std::fabs(ER), .hardening_ratio = H, .beta = std::clamp(B, 0., 1.)}
+NonlocalBilinearJ2::NonlocalBilinearJ2(const unsigned T, const double E, const double V, const double Y, const double PE, const double ER, const double H, const double B, const double R)
+    : DataNonlocalBilinearJ2{.elastic_modulus = std::fabs(E), .poissons_ratio = V, .yield_stress = std::fabs(Y), .plastic_strain_threshold = PE, .evolution_rate = std::fabs(ER), .hardening_ratio = H, .beta = std::clamp(B, 0., 1.)}
     , Material3D(T, R) {}
 
 int NonlocalBilinearJ2::initialize(const shared_ptr<DomainBase>&) {
@@ -52,27 +52,45 @@ int NonlocalBilinearJ2::update_trial_status(const vec& t_strain) {
     vec plastic_strain(&trial_history(7), 6, false, true);
 
     trial_stiffness = initial_stiffness;
-    trial_stress.head(6) = trial_stiffness(u_dof, u_dof) * (trial_strain.head(6) - plastic_strain);
+    trial_stress.head(6) = trial_stiffness(UD, UD) * (trial_strain.head(6) - plastic_strain);
 
     const vec shifted_stress = tensor::dev(trial_stress.head(6)) - back_stress;
 
     const auto norm_shifted_stress = tensor::stress::norm(shifted_stress);
 
     const auto yield_surf = yield_stress + isotropic_modulus * eqv_plastic_strain;
+    const auto yield_func = norm_shifted_stress - root_two_third * std::max(yield_surf, 0.);
+    const auto yield_flag = yield_func > 0.;
 
-    if(const auto yield_func = norm_shifted_stress - root_two_third * std::max(yield_surf, 0.); yield_func > 0.) {
+    rowvec ppepe;
+
+    if(yield_flag) {
         const auto tmp_a = double_shear + two_third * (kinematic_modulus + (yield_surf > 0. ? isotropic_modulus : 0.));
         const auto gamma = yield_func / tmp_a;
 
         auto tmp_b = double_shear * gamma / norm_shifted_stress;
         trial_stress.head(6) -= tmp_b * shifted_stress;
 
-        back_stress += two_third * kinematic_modulus * gamma / norm_shifted_stress * shifted_stress;
+        const vec unit_n = shifted_stress / norm_shifted_stress;
+
         eqv_plastic_strain += root_two_third * gamma;
+        back_stress += two_third * kinematic_modulus * gamma * unit_n;
+        plastic_strain += gamma * unit_n % tensor::stress::norm_weight;
+
+        ppepe = root_two_third * double_shear / tmp_a * unit_n.t();
 
         tmp_b *= double_shear;
-        trial_stiffness(u_dof, u_dof) += (tmp_b - square_double_shear / tmp_a) / norm_shifted_stress / norm_shifted_stress * shifted_stress * shifted_stress.t() - tmp_b * unit_dev_tensor;
+        trial_stiffness(UD, UD) += (tmp_b - square_double_shear / tmp_a) * unit_n * unit_n.t() - tmp_b * unit_dev_tensor;
     }
+
+    if(eqv_plastic_strain > plastic_strain_threshold) {
+        trial_stress(6) = 1. - std::exp(evolution_rate * (plastic_strain_threshold - eqv_plastic_strain));
+        if(yield_flag) trial_stiffness(DD, UD) = (1. - trial_stress(6)) * evolution_rate * ppepe;
+    }
+
+    trial_stiffness(UD, DD) = -trial_stress(UD);
+    trial_stress(UD) *= 1. - trial_strain(6);
+    trial_stiffness(UD, UD) *= 1. - trial_strain(6);
 
     return SUANPAN_SUCCESS;
 }

--- a/Material/Material3D/Nonlocal/NonlocalBilinearJ2.h
+++ b/Material/Material3D/Nonlocal/NonlocalBilinearJ2.h
@@ -33,19 +33,20 @@
 #include <Material/Material3D/Material3D.h>
 
 struct DataNonlocalBilinearJ2 {
-    const double elastic_modulus; // elastic modulus
-    const double poissons_ratio;  // poisson's ratio
-    const double yield_stress;    // initial yield stress
-    const double evolution_rate;  // evolution rate
-    const double hardening_ratio; // hardening ratio
-    const double beta;            // isotropic (1.0) / kinematic (0.0) hardening factor
+    const double elastic_modulus;          // elastic modulus
+    const double poissons_ratio;           // poisson's ratio
+    const double yield_stress;             // initial yield stress
+    const double plastic_strain_threshold; // threshold
+    const double evolution_rate;           // evolution rate
+    const double hardening_ratio;          // hardening ratio
+    const double beta;                     // isotropic (1.0) / kinematic (0.0) hardening factor
 };
 
 class NonlocalBilinearJ2 final : protected DataNonlocalBilinearJ2, public Material3D {
     static const double two_third;
     static const double root_two_third;
     static const mat unit_dev_tensor;
-    static const uvec u_dof, d_dof;
+    static const uvec UD, DD;
 
     const double shear_modulus = elastic_modulus / (2. + 2. * poissons_ratio); // shear modulus
     const double double_shear = 2. * shear_modulus;                            // double shear modulus
@@ -59,6 +60,7 @@ public:
         double,   // elastic modulus
         double,   // poisson's ratio
         double,   // initial yield stress
+        double,   // plastic strain threshold
         double,   // evolution rate
         double,   // hardening ratio
         double,   // isotropic (1.0) / kinematic (0.0) hardening factor

--- a/Material/Material3D/Nonlocal/NonlocalBilinearJ2.h
+++ b/Material/Material3D/Nonlocal/NonlocalBilinearJ2.h
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (C) 2017-2026 Theodore Chang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+/**
+ * @class NonlocalBilinearJ2
+ * @brief The NonlocalBilinearJ2 class defines a bilinear hardening material with mixed
+ * hardening (isotropic and kinematic) based on J2 plasticity rule with a nonlocal failure quantity.
+ *
+ * @author tlc
+ * @date 18/08/2026
+ * @version 1.0.0
+ * @file NonlocalBilinearJ2.h
+ * @addtogroup Material-3D
+ * @{
+ */
+
+#ifndef NONLOCALBILINEARJ2_H
+#define NONLOCALBILINEARJ2_H
+
+#include <Material/Material3D/Material3D.h>
+
+struct DataNonlocalBilinearJ2 {
+    const double elastic_modulus; // elastic modulus
+    const double poissons_ratio;  // poisson's ratio
+    const double yield_stress;    // initial yield stress
+    const double evolution_rate;  // evolution rate
+    const double hardening_ratio; // hardening ratio
+    const double beta;            // isotropic (1.0) / kinematic (0.0) hardening factor
+};
+
+class NonlocalBilinearJ2 final : protected DataNonlocalBilinearJ2, public Material3D {
+    static const double two_third;
+    static const double root_two_third;
+    static const mat unit_dev_tensor;
+    static const uvec u_dof, d_dof;
+
+    const double shear_modulus = elastic_modulus / (2. + 2. * poissons_ratio); // shear modulus
+    const double double_shear = 2. * shear_modulus;                            // double shear modulus
+    const double square_double_shear = double_shear * double_shear;            // double shear modulus squared
+    const double isotropic_modulus = beta * elastic_modulus * hardening_ratio / (1. - hardening_ratio);
+    const double kinematic_modulus = (1. - beta) * elastic_modulus * hardening_ratio / (1. - hardening_ratio);
+
+public:
+    NonlocalBilinearJ2(
+        unsigned, // tag
+        double,   // elastic modulus
+        double,   // poisson's ratio
+        double,   // initial yield stress
+        double,   // evolution rate
+        double,   // hardening ratio
+        double,   // isotropic (1.0) / kinematic (0.0) hardening factor
+        double    // density
+    );
+
+    int initialize(const shared_ptr<DomainBase>&) override;
+
+    unique_ptr<Material> unique_copy() override;
+
+    [[nodiscard]] unsigned nonlocal_size() const override { return 1u; }
+
+    [[nodiscard]] double get(Parameter) const override;
+
+    int update_trial_status(const vec&) override;
+
+    int clear_status() override;
+    int commit_status() override;
+    int reset_status() override;
+
+    void print() override;
+};
+
+#endif
+
+//! @}

--- a/Material/MaterialParser.cpp
+++ b/Material/MaterialParser.cpp
@@ -801,6 +801,28 @@ namespace {
         return_obj = std::make_unique<BilinearJ2>(tag, elastic_modulus, poissons_ratio, yield_stress, hardening_ratio, beta, density);
     }
 
+    void new_nonlocalbilinearj2(unique_ptr<Material>& return_obj, std::istringstream& command) {
+        unsigned tag;
+        if(!get_input(command, tag)) {
+            suanpan_error("A valid tag is required.\n");
+            return;
+        }
+
+        double elastic_modulus, poissons_ratio, yield_stress, plastic_strain_threshold, evolution_rate;
+        if(!get_input(command, elastic_modulus, poissons_ratio, yield_stress, plastic_strain_threshold, evolution_rate)) {
+            suanpan_error("A valid parameter is required.\n");
+            return;
+        }
+
+        auto hardening_ratio = 0., beta = 1., density = 0.;
+        if(!get_optional_input(command, hardening_ratio, beta, density)) {
+            suanpan_error("A valid parameter is required.\n");
+            return;
+        }
+
+        return_obj = std::make_unique<NonlocalBilinearJ2>(tag, elastic_modulus, poissons_ratio, yield_stress, plastic_strain_threshold, evolution_rate, hardening_ratio, beta, density);
+    }
+
     void new_bilinearmises1d(unique_ptr<Material>& return_obj, std::istringstream& command) {
         unsigned tag;
         if(!get_input(command, tag)) {
@@ -3674,6 +3696,7 @@ int create_new_material(const shared_ptr<DomainBase>& domain, std::istringstream
     else if(is_equal(material_id, "BilinearElastic1D")) new_bilinearelastic1d(new_material, command);
     else if(is_equal(material_id, "BilinearHoffman")) new_bilinearorthotropic(new_material, command, true);
     else if(is_equal(material_id, "BilinearJ2")) new_bilinearj2(new_material, command);
+    else if(is_equal(material_id, "NonlocalBilinearJ2")) new_nonlocalbilinearj2(new_material, command);
     else if(is_equal(material_id, "BilinearMises1D")) new_bilinearmises1d(new_material, command);
     else if(is_equal(material_id, "BilinearOO")) new_bilinearoo(new_material, command);
     else if(is_equal(material_id, "BilinearPeric")) new_bilinearperic(new_material, command);


### PR DESCRIPTION
Introduce the NonlocalBilinearJ2 material model, enhancing the material parser with a new function for its creation. Include a plastic strain threshold and refactor related constants. Add a test model to validate the implementation.