### PR TITLE
Refactor nonlocal material classes to include reference length and diffusion rate

### DIFF
--- a/Element/Cube/Nonlocal/NonlocalC3D8.cpp
+++ b/Element/Cube/Nonlocal/NonlocalC3D8.cpp
@@ -39,8 +39,8 @@ NonlocalC3D8::IntegrationPoint::IntegrationPoint(vec&& C, const double W, unique
     }
 }
 
-NonlocalC3D8::NonlocalC3D8(const unsigned T, uvec&& N, const unsigned M, const double CL)
-    : MaterialElement3D(T, c_node, c_dof, std::move(N), uvec{M}, false, {Node::DOF::U1, Node::DOF::U2, Node::DOF::U3, Node::DOF::NL1}) { access::rw(characteristic_length) = std::fabs(CL); }
+NonlocalC3D8::NonlocalC3D8(const unsigned T, uvec&& N, const unsigned M)
+    : MaterialElement3D(T, c_node, c_dof, std::move(N), uvec{M}, false, {Node::DOF::U1, Node::DOF::U2, Node::DOF::U3, Node::DOF::NL1}) {}
 
 int NonlocalC3D8::initialize(const shared_ptr<DomainBase>& D) {
     auto& material_proto = D->get<Material>(material_tag(0));
@@ -69,7 +69,7 @@ int NonlocalC3D8::initialize(const shared_ptr<DomainBase>& D) {
 
         auto& c_pt = int_pt.emplace_back(std::move(t_vec), plan(I, 3) * det(jacob), material_proto->unique_copy(), n_mat, pn_mat);
 
-        const_mat -= c_pt.weight * n_mat.t() * n_mat + c_pt.weight * characteristic_length * characteristic_length * pn_mat.t() * pn_mat;
+        const_mat -= c_pt.weight * pn_mat.t() * pn_mat;
         initial_stiffness += c_pt.weight * c_pt.strain_mat.t() * ini_stiffness * c_pt.strain_mat;
     }
 

--- a/Element/Cube/Nonlocal/NonlocalC3D8.h
+++ b/Element/Cube/Nonlocal/NonlocalC3D8.h
@@ -53,8 +53,7 @@ public:
     NonlocalC3D8(
         unsigned, // tag
         uvec&&,   // node tag
-        unsigned, // material tag
-        double    // characteristic length
+        unsigned  // material tag
     );
 
     int initialize(const shared_ptr<DomainBase>&) override;

--- a/Element/ElementParser.cpp
+++ b/Element/ElementParser.cpp
@@ -1127,13 +1127,7 @@ namespace {
             return;
         }
 
-        double characteristic_length;
-        if(!get_input(command, characteristic_length)) {
-            suanpan_error("A valid characteristic length is required.\n");
-            return;
-        }
-
-        return_obj = std::make_unique<NonlocalC3D8>(tag, std::move(node_tag), material_tag, characteristic_length);
+        return_obj = std::make_unique<NonlocalC3D8>(tag, std::move(node_tag), material_tag);
     }
 
     template<bool monolithic> void new_dcp3(unique_ptr<Element>& return_obj, std::istringstream& command) {
@@ -1235,19 +1229,13 @@ namespace {
             return;
         }
 
-        double characteristic_length;
-        if(!get_input(command, characteristic_length)) {
-            suanpan_error("A valid characteristic length is required.\n");
-            return;
-        }
-
         auto thickness = 1.;
         if(!get_optional_input(command, thickness)) {
             suanpan_error("A valid thickness is required.\n");
             return;
         }
 
-        return_obj = std::make_unique<NonlocalCP4>(tag, std::move(node_tag), material_tag, characteristic_length, thickness);
+        return_obj = std::make_unique<NonlocalCP4>(tag, std::move(node_tag), material_tag, thickness);
     }
 
     void new_dkt3(unique_ptr<Element>& return_obj, std::istringstream& command) {

--- a/Element/Membrane/Nonlocal/NonlocalCP4.cpp
+++ b/Element/Membrane/Nonlocal/NonlocalCP4.cpp
@@ -40,9 +40,9 @@ NonlocalCP4::IntegrationPoint::IntegrationPoint(vec&& C, const double W, unique_
     }
 }
 
-NonlocalCP4::NonlocalCP4(const unsigned T, uvec&& N, const unsigned M, const double CL, const double TH)
+NonlocalCP4::NonlocalCP4(const unsigned T, uvec&& N, const unsigned M, const double TH)
     : MaterialElement2D(T, m_node, m_dof, std::move(N), uvec{M}, false, {Node::DOF::U1, Node::DOF::U2, Node::DOF::NL1})
-    , thickness(TH) { access::rw(characteristic_length) = std::fabs(CL); }
+    , thickness(TH) {}
 
 int NonlocalCP4::initialize(const shared_ptr<DomainBase>& D) {
     auto& material_proto = D->get<Material>(material_tag(0));
@@ -73,7 +73,7 @@ int NonlocalCP4::initialize(const shared_ptr<DomainBase>& D) {
         const mat pn_mat = solve(jacob, pn);
         auto& c_pt = int_pt.emplace_back(std::move(t_vec), plan(I, 2) * det(jacob) * thickness, material_proto->unique_copy(), shape::quad(t_vec, 0), pn_mat);
 
-        const_mat -= c_pt.weight * c_pt.n_mat.t() * c_pt.n_mat + c_pt.weight * characteristic_length * characteristic_length * pn_mat.t() * pn_mat;
+        const_mat -= c_pt.weight * pn_mat.t() * pn_mat;
 
         initial_stiffness += c_pt.weight * c_pt.b_mat.t() * ini_stiffness * c_pt.b_mat;
     }

--- a/Element/Membrane/Nonlocal/NonlocalCP4.h
+++ b/Element/Membrane/Nonlocal/NonlocalCP4.h
@@ -57,7 +57,6 @@ public:
         unsigned, // tag
         uvec&&,   // node tag
         unsigned, // material tag
-        double,   // characteristic length
         double    // thickness
     );
 

--- a/Example/Element/NonlocalC3D8.supan
+++ b/Example/Element/NonlocalC3D8.supan
@@ -9,9 +9,9 @@ node 6 .5 .5 .5
 node 7 -.5 .5 .5
 node 8 -.5 -.5 .5
 
-material NonlocalElastic3D 1 1E4 .2 1e1 2.
+material NonlocalElastic3D 1 1E4 .2 1e1 2. 1. 1.
 
-element NonlocalC3D8 1 1 2 3 4 5 6 7 8 1 1.
+element NonlocalC3D8 1 1 2 3 4 5 6 7 8 1
 
 fix2 1 1 3 4 7 8
 fix2 2 2 1 4 5 8

--- a/Example/Element/NonlocalC3D8.supan
+++ b/Example/Element/NonlocalC3D8.supan
@@ -9,7 +9,7 @@ node 6 .5 .5 .5
 node 7 -.5 .5 .5
 node 8 -.5 -.5 .5
 
-material NonlocalElastic3D 1 1E4 .2 1e1 2. 1. 1.
+material NonlocalElastic3D 1 1E4 .2 1e1 2. 1. 0.
 
 element NonlocalC3D8 1 1 2 3 4 5 6 7 8 1
 

--- a/Example/Element/NonlocalCP4.supan
+++ b/Example/Element/NonlocalCP4.supan
@@ -15,13 +15,13 @@ node 11 8 2
 node 12 10 2
 
 material PlaneStress 1 2
-material NonlocalElastic3D 2 1E4 .2 1e1 2. 1e-8
+material NonlocalElastic3D 2 1E4 .2 1e1 2. 1. 1. 1e-8
 
-element NonlocalCP4 1 1 2 8 7 1 1.
-element NonlocalCP4 2 2 3 9 8 1 1.
-element NonlocalCP4 3 3 4 10 9 1 1.
-element NonlocalCP4 4 4 5 11 10 1 1.
-element NonlocalCP4 5 5 6 12 11 1 1.
+element NonlocalCP4 1 1 2 8 7 1
+element NonlocalCP4 2 2 3 9 8 1
+element NonlocalCP4 3 3 4 10 9 1
+element NonlocalCP4 4 4 5 11 10 1
+element NonlocalCP4 5 5 6 12 11 1
 
 fix 1 1 1 7
 fix 2 2 1

--- a/Example/Element/NonlocalCP4.supan
+++ b/Example/Element/NonlocalCP4.supan
@@ -15,7 +15,7 @@ node 11 8 2
 node 12 10 2
 
 material PlaneStress 1 2
-material NonlocalElastic3D 2 1E4 .2 1e1 2. 1. 1. 1e-8
+material NonlocalElastic3D 2 1E4 .2 1e1 2. 1. 0. 1e-8
 
 element NonlocalCP4 1 1 2 8 7 1
 element NonlocalCP4 2 2 3 9 8 1

--- a/Example/Material/NonlocalBilinearJ2.supan
+++ b/Example/Material/NonlocalBilinearJ2.supan
@@ -9,7 +9,7 @@ node 6 .5 .5 .5
 node 7 -.5 .5 .5
 node 8 -.5 -.5 .5
 
-material NonlocalBilinearJ2 1 1e4 .2 200 1e-1 5. 1. 0. .02
+material NonlocalBilinearJ2 1 1e4 .2 200 1e-1 5. 1. 100. .02
 
 element NonlocalC3D8 1 1 2 3 4 5 6 7 8 1
 

--- a/Example/Material/NonlocalBilinearJ2.supan
+++ b/Example/Material/NonlocalBilinearJ2.supan
@@ -9,7 +9,7 @@ node 6 .5 .5 .5
 node 7 -.5 .5 .5
 node 8 -.5 -.5 .5
 
-material NonlocalBilinearJ2 1 1e4 .2 200 1e-1 5. 1. 1. .02
+material NonlocalBilinearJ2 1 1e4 .2 200 1e-1 5. 1. 0. .02
 
 element NonlocalC3D8 1 1 2 3 4 5 6 7 8 1
 

--- a/Example/Material/NonlocalBilinearJ2.supan
+++ b/Example/Material/NonlocalBilinearJ2.supan
@@ -9,9 +9,9 @@ node 6 .5 .5 .5
 node 7 -.5 .5 .5
 node 8 -.5 -.5 .5
 
-material NonlocalBilinearJ2 1 1e4 .2 200 1e-1 5. .02
+material NonlocalBilinearJ2 1 1e4 .2 200 1e-1 5. 1. 1. .02
 
-element NonlocalC3D8 1 1 2 3 4 5 6 7 8 1 1.
+element NonlocalC3D8 1 1 2 3 4 5 6 7 8 1
 
 fix2 1 1 3 4 7 8
 fix2 2 2 1 4 5 8

--- a/Material/Material3D/Material3D.cpp
+++ b/Material/Material3D/Material3D.cpp
@@ -81,6 +81,30 @@ std::vector<vec> Material3D::record(const OutputType P) const {
 NonlocalMaterial3D::NonlocalMaterial3D(const unsigned T, const double R)
     : Material(T, MaterialType::D3, R) {}
 
+int NonlocalMaterial3D::clear_status() {
+    current_strain.zeros();
+    current_stress.zeros();
+    current_history = initial_history;
+    current_stiffness = initial_stiffness;
+    return reset_status();
+}
+
+int NonlocalMaterial3D::commit_status() {
+    current_strain = trial_strain;
+    current_stress = trial_stress;
+    current_history = trial_history;
+    current_stiffness = trial_stiffness;
+    return SUANPAN_SUCCESS;
+}
+
+int NonlocalMaterial3D::reset_status() {
+    trial_strain = current_strain;
+    trial_stress = current_stress;
+    trial_history = current_history;
+    trial_stiffness = current_stiffness;
+    return SUANPAN_SUCCESS;
+}
+
 std::vector<vec> NonlocalMaterial3D::record(const OutputType P) const {
     if(P == OutputType::SP) {
         vec principal_stress;

--- a/Material/Material3D/Material3D.h
+++ b/Material/Material3D/Material3D.h
@@ -53,6 +53,10 @@ public:
         double    // density
     );
 
+    int clear_status() override;
+    int commit_status() override;
+    int reset_status() override;
+
     [[nodiscard]] std::vector<vec> record(OutputType) const override;
 };
 

--- a/Material/Material3D/Nonlocal/NonlocalBilinearJ2.cpp
+++ b/Material/Material3D/Nonlocal/NonlocalBilinearJ2.cpp
@@ -100,6 +100,8 @@ int NonlocalBilinearJ2::update_trial_status(const vec& t_strain) {
     trial_stiffness(DD, UD) *= s * s + 2. * s * ds * (trial_stress(6) - trial_strain(6));
     trial_stiffness(DD, DD).fill(-s * s);
 
+    trial_stress(6) = s * s * (trial_stress(6) - trial_strain(6));
+
     return SUANPAN_SUCCESS;
 }
 

--- a/Material/Material3D/Nonlocal/NonlocalBilinearJ2.cpp
+++ b/Material/Material3D/Nonlocal/NonlocalBilinearJ2.cpp
@@ -96,11 +96,12 @@ int NonlocalBilinearJ2::update_trial_status(const vec& t_strain) {
     trial_stiffness(UD, UD) *= 1. - trial_strain(6);
 
     const auto [s, ds] = compute_scale(trial_stress(6));
+    const auto s2 = s * s;
 
-    trial_stiffness(DD, UD) *= s * s + 2. * s * ds * (trial_stress(6) - trial_strain(6));
-    trial_stiffness(DD, DD).fill(-s * s);
+    trial_stiffness(DD, UD) *= s2 + 2. * s * ds * (trial_stress(6) - trial_strain(6));
+    trial_stiffness(DD, DD).fill(-s2);
 
-    trial_stress(6) = s * s * (trial_stress(6) - trial_strain(6));
+    trial_stress(6) = s2 * (trial_stress(6) - trial_strain(6));
 
     return SUANPAN_SUCCESS;
 }

--- a/Material/Material3D/Nonlocal/NonlocalBilinearJ2.cpp
+++ b/Material/Material3D/Nonlocal/NonlocalBilinearJ2.cpp
@@ -25,12 +25,15 @@ const mat NonlocalBilinearJ2::unit_dev_tensor = tensor::unit_deviatoric_tensor4(
 const uvec NonlocalBilinearJ2::UD{0, 1, 2, 3, 4, 5};
 const uvec NonlocalBilinearJ2::DD{6};
 
-NonlocalBilinearJ2::NonlocalBilinearJ2(const unsigned T, const double E, const double V, const double Y, const double PE, const double ER, const double H, const double B, const double R)
-    : DataNonlocalBilinearJ2{.elastic_modulus = std::fabs(E), .poissons_ratio = V, .yield_stress = std::fabs(Y), .plastic_strain_threshold = PE, .evolution_rate = std::fabs(ER), .hardening_ratio = H, .beta = std::clamp(B, 0., 1.)}
-    , Material3D(T, R) {}
+NonlocalBilinearJ2::NonlocalBilinearJ2(const unsigned T, const double E, const double V, const double Y, const double PE, const double ER, const double RL, const double DR, const double H, const double B, const double R)
+    : DataNonlocalBilinearJ2{.elastic_modulus = std::fabs(E), .poissons_ratio = V, .yield_stress = std::fabs(Y), .plastic_strain_threshold = PE, .evolution_rate = std::fabs(ER), .reference_length = std::fabs(RL), .diffusion_rate = std::fabs(DR), .hardening_ratio = H, .beta = std::clamp(B, 0., 1.)}
+    , NonlocalMaterial3D(T, R) {}
 
 int NonlocalBilinearJ2::initialize(const shared_ptr<DomainBase>&) {
-    trial_stiffness = current_stiffness = initial_stiffness = tensor::isotropic_stiffness(elastic_modulus, poissons_ratio, nonlocal_size());
+    initial_stiffness = tensor::isotropic_stiffness(elastic_modulus, poissons_ratio, nonlocal_size());
+    const auto [s, ds] = compute_scale(0.);
+    initial_stiffness(DD, DD).fill(-s * s);
+    trial_stiffness = current_stiffness = initial_stiffness;
 
     initialize_history(13);
 
@@ -91,6 +94,11 @@ int NonlocalBilinearJ2::update_trial_status(const vec& t_strain) {
     trial_stiffness(UD, DD) = -trial_stress(UD);
     trial_stress(UD) *= 1. - trial_strain(6);
     trial_stiffness(UD, UD) *= 1. - trial_strain(6);
+
+    const auto [s, ds] = compute_scale(trial_stress(6));
+
+    trial_stiffness(DD, UD) *= s * s + 2. * s * ds * (trial_stress(6) - trial_strain(6));
+    trial_stiffness(DD, DD).fill(-s * s);
 
     return SUANPAN_SUCCESS;
 }

--- a/Material/Material3D/Nonlocal/NonlocalBilinearJ2.h
+++ b/Material/Material3D/Nonlocal/NonlocalBilinearJ2.h
@@ -56,7 +56,12 @@ class NonlocalBilinearJ2 final : protected DataNonlocalBilinearJ2, public Nonloc
     const double isotropic_modulus = beta * elastic_modulus * hardening_ratio / (1. - hardening_ratio);
     const double kinematic_modulus = (1. - beta) * elastic_modulus * hardening_ratio / (1. - hardening_ratio);
 
-    [[nodiscard]] std::pair<double, double> compute_scale(double) const { return {1. / reference_length, 0.}; }
+    [[nodiscard]] std::pair<double, double> compute_scale(const double k) const {
+        const auto exp_term = std::exp(diffusion_rate * k);
+        const auto s = exp_term / reference_length;
+
+        return {s, diffusion_rate * s};
+    }
 
 public:
     NonlocalBilinearJ2(

--- a/Material/Material3D/Nonlocal/NonlocalBilinearJ2.h
+++ b/Material/Material3D/Nonlocal/NonlocalBilinearJ2.h
@@ -38,11 +38,13 @@ struct DataNonlocalBilinearJ2 {
     const double yield_stress;             // initial yield stress
     const double plastic_strain_threshold; // threshold
     const double evolution_rate;           // evolution rate
+    const double reference_length;
+    const double diffusion_rate;
     const double hardening_ratio;          // hardening ratio
     const double beta;                     // isotropic (1.0) / kinematic (0.0) hardening factor
 };
 
-class NonlocalBilinearJ2 final : protected DataNonlocalBilinearJ2, public Material3D {
+class NonlocalBilinearJ2 final : protected DataNonlocalBilinearJ2, public NonlocalMaterial3D {
     static const double two_third;
     static const double root_two_third;
     static const mat unit_dev_tensor;
@@ -54,6 +56,8 @@ class NonlocalBilinearJ2 final : protected DataNonlocalBilinearJ2, public Materi
     const double isotropic_modulus = beta * elastic_modulus * hardening_ratio / (1. - hardening_ratio);
     const double kinematic_modulus = (1. - beta) * elastic_modulus * hardening_ratio / (1. - hardening_ratio);
 
+    [[nodiscard]] std::pair<double, double> compute_scale(double) const { return {1. / reference_length, 0.}; }
+
 public:
     NonlocalBilinearJ2(
         unsigned, // tag
@@ -61,6 +65,8 @@ public:
         double,   // poisson's ratio
         double,   // initial yield stress
         double,   // plastic strain threshold
+        double,   // evolution rate
+        double,   // reference length
         double,   // evolution rate
         double,   // hardening ratio
         double,   // isotropic (1.0) / kinematic (0.0) hardening factor

--- a/Material/Material3D/Nonlocal/NonlocalBilinearJ2.h
+++ b/Material/Material3D/Nonlocal/NonlocalBilinearJ2.h
@@ -38,10 +38,10 @@ struct DataNonlocalBilinearJ2 {
     const double yield_stress;             // initial yield stress
     const double plastic_strain_threshold; // threshold
     const double evolution_rate;           // evolution rate
-    const double reference_length;
-    const double diffusion_rate;
-    const double hardening_ratio; // hardening ratio
-    const double beta;            // isotropic (1.0) / kinematic (0.0) hardening factor
+    const double reference_length;         // reference length
+    const double diffusion_rate;           // diffusion rate
+    const double hardening_ratio;          // hardening ratio
+    const double beta;                     // isotropic (1.0) / kinematic (0.0) hardening factor
 };
 
 class NonlocalBilinearJ2 final : protected DataNonlocalBilinearJ2, public NonlocalMaterial3D {
@@ -59,7 +59,6 @@ class NonlocalBilinearJ2 final : protected DataNonlocalBilinearJ2, public Nonloc
     [[nodiscard]] std::pair<double, double> compute_scale(const double k) const {
         const auto exp_term = std::exp(diffusion_rate * k);
         const auto s = exp_term / reference_length;
-
         return {s, diffusion_rate * s};
     }
 

--- a/Material/Material3D/Nonlocal/NonlocalBilinearJ2.h
+++ b/Material/Material3D/Nonlocal/NonlocalBilinearJ2.h
@@ -40,8 +40,8 @@ struct DataNonlocalBilinearJ2 {
     const double evolution_rate;           // evolution rate
     const double reference_length;
     const double diffusion_rate;
-    const double hardening_ratio;          // hardening ratio
-    const double beta;                     // isotropic (1.0) / kinematic (0.0) hardening factor
+    const double hardening_ratio; // hardening ratio
+    const double beta;            // isotropic (1.0) / kinematic (0.0) hardening factor
 };
 
 class NonlocalBilinearJ2 final : protected DataNonlocalBilinearJ2, public NonlocalMaterial3D {

--- a/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.cpp
+++ b/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.cpp
@@ -22,13 +22,16 @@
 const uvec NonlocalIsotropicElastic3D::u_dof{0, 1, 2, 3, 4, 5};
 const uvec NonlocalIsotropicElastic3D::d_dof{6};
 
-NonlocalIsotropicElastic3D::NonlocalIsotropicElastic3D(const unsigned T, const double E, const double P, const double ME, const double ER, const EnergyType ET, const double R)
-    : DataNonlocalIsotropicElastic3D{.elastic_modulus = std::fabs(E), .poissons_ratio = std::fabs(P), .maximum_energy = std::fabs(ME), .evolution_rate = std::fabs(ER)}
+NonlocalIsotropicElastic3D::NonlocalIsotropicElastic3D(const unsigned T, const double E, const double P, const double ME, const double ER, const double RL, const double DR, const EnergyType ET, const double R)
+    : DataNonlocalIsotropicElastic3D{.elastic_modulus = std::fabs(E), .poissons_ratio = std::fabs(P), .maximum_energy = std::fabs(ME), .evolution_rate = std::fabs(ER), .reference_length = std::fabs(RL), .diffusion_rate = std::fabs(DR)}
     , NonlocalMaterial3D(T, R)
     , energy_type(ET) {}
 
 int NonlocalIsotropicElastic3D::initialize(const shared_ptr<DomainBase>&) {
-    trial_stiffness = current_stiffness = initial_stiffness = tensor::isotropic_stiffness(elastic_modulus, poissons_ratio, nonlocal_size());
+    initial_stiffness = tensor::isotropic_stiffness(elastic_modulus, poissons_ratio, nonlocal_size());
+    const auto [s, ds] = compute_scale(0.);
+    initial_stiffness(d_dof, d_dof).fill(-s * s);
+    trial_stiffness = current_stiffness = initial_stiffness;
 
     initialize_history(1u);
 
@@ -78,6 +81,11 @@ int NonlocalIsotropicElastic3D::update_trial_status(const vec& t_strain) {
 
     trial_stress(u_dof) *= 1. - trial_strain(6);
     trial_stiffness(u_dof, u_dof) *= 1. - trial_strain(6);
+
+    const auto [s, ds] = compute_scale(trial_stress(6));
+
+    trial_stiffness(d_dof, u_dof) *= s * s + 2. * s * ds * (trial_stress(6) - trial_strain(6));
+    trial_stiffness(d_dof, d_dof).fill(-s * s);
 
     return SUANPAN_SUCCESS;
 }

--- a/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.cpp
+++ b/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.cpp
@@ -90,30 +90,6 @@ int NonlocalIsotropicElastic3D::update_trial_status(const vec& t_strain) {
     return SUANPAN_SUCCESS;
 }
 
-int NonlocalIsotropicElastic3D::clear_status() {
-    current_strain = trial_strain.zeros();
-    current_stress = trial_stress.zeros();
-    current_stiffness = trial_stiffness = initial_stiffness;
-    current_history = trial_history = initial_history;
-    return SUANPAN_SUCCESS;
-}
-
-int NonlocalIsotropicElastic3D::commit_status() {
-    current_strain = trial_strain;
-    current_stress = trial_stress;
-    current_stiffness = trial_stiffness;
-    current_history = trial_history;
-    return SUANPAN_SUCCESS;
-}
-
-int NonlocalIsotropicElastic3D::reset_status() {
-    trial_strain = current_strain;
-    trial_stress = current_stress;
-    trial_stiffness = current_stiffness;
-    trial_history = current_history;
-    return SUANPAN_SUCCESS;
-}
-
 void NonlocalIsotropicElastic3D::print() {
     suanpan_info("A 3D isotropic elastic material with E={:.4E} and nu={:.4E}.\n", elastic_modulus, poissons_ratio);
 }

--- a/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.cpp
+++ b/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.cpp
@@ -19,8 +19,8 @@
 
 #include <Toolbox/tensor.h>
 
-const uvec NonlocalIsotropicElastic3D::u_dof{0, 1, 2, 3, 4, 5};
-const uvec NonlocalIsotropicElastic3D::d_dof{6};
+const uvec NonlocalIsotropicElastic3D::UD{0, 1, 2, 3, 4, 5};
+const uvec NonlocalIsotropicElastic3D::DD{6};
 
 NonlocalIsotropicElastic3D::NonlocalIsotropicElastic3D(const unsigned T, const double E, const double P, const double ME, const double ER, const double RL, const double DR, const EnergyType ET, const double R)
     : DataNonlocalIsotropicElastic3D{.elastic_modulus = std::fabs(E), .poissons_ratio = std::fabs(P), .maximum_energy = std::fabs(ME), .evolution_rate = std::fabs(ER), .reference_length = std::fabs(RL), .diffusion_rate = std::fabs(DR)}
@@ -30,7 +30,7 @@ NonlocalIsotropicElastic3D::NonlocalIsotropicElastic3D(const unsigned T, const d
 int NonlocalIsotropicElastic3D::initialize(const shared_ptr<DomainBase>&) {
     initial_stiffness = tensor::isotropic_stiffness(elastic_modulus, poissons_ratio, nonlocal_size());
     const auto [s, ds] = compute_scale(0.);
-    initial_stiffness(d_dof, d_dof).fill(-s * s);
+    initial_stiffness(DD, DD).fill(-s * s);
     trial_stiffness = current_stiffness = initial_stiffness;
 
     initialize_history(1u);
@@ -64,28 +64,28 @@ int NonlocalIsotropicElastic3D::update_trial_status(const vec& t_strain) {
         const auto [tension_projector, tension_derivative] = transform::stress::eigen_to_tensile_derivative(principal_stress, principal_direction);
 
         target_stress = tension_projector * target_stress;
-        target_der = solve(initial_stiffness(u_dof, u_dof), target_stress).t() * tension_derivative;
+        target_der = solve(initial_stiffness(UD, UD), target_stress).t() * tension_derivative;
         if(EnergyType::DEV_TENSILE == energy_type) dev(target_der);
-        target_der *= initial_stiffness(u_dof, u_dof);
+        target_der *= initial_stiffness(UD, UD);
     }
 
-    if(const auto excessive_energy = .5 * dot(solve(initial_stiffness(u_dof, u_dof), target_stress), target_stress) - maximum_energy; excessive_energy > trial_history(0)) {
+    if(const auto excessive_energy = .5 * dot(solve(initial_stiffness(UD, UD), target_stress), target_stress) - maximum_energy; excessive_energy > trial_history(0)) {
         trial_history(0) = excessive_energy;
         const auto sqrt_term = std::sqrt(excessive_energy / maximum_energy + 1.);
         trial_stress(6) = 1. - std::exp(evolution_rate * (1. - sqrt_term));
-        trial_stiffness(d_dof, u_dof) = (1. - trial_stress(6)) * evolution_rate * .5 / sqrt_term / maximum_energy * target_der;
+        trial_stiffness(DD, UD) = (1. - trial_stress(6)) * evolution_rate * .5 / sqrt_term / maximum_energy * target_der;
     }
     else trial_stress(6) = current_stress(6);
 
-    trial_stiffness(u_dof, d_dof) = -trial_stress(u_dof);
+    trial_stiffness(UD, DD) = -trial_stress(UD);
 
-    trial_stress(u_dof) *= 1. - trial_strain(6);
-    trial_stiffness(u_dof, u_dof) *= 1. - trial_strain(6);
+    trial_stress(UD) *= 1. - trial_strain(6);
+    trial_stiffness(UD, UD) *= 1. - trial_strain(6);
 
     const auto [s, ds] = compute_scale(trial_stress(6));
 
-    trial_stiffness(d_dof, u_dof) *= s * s + 2. * s * ds * (trial_stress(6) - trial_strain(6));
-    trial_stiffness(d_dof, d_dof).fill(-s * s);
+    trial_stiffness(DD, UD) *= s * s + 2. * s * ds * (trial_stress(6) - trial_strain(6));
+    trial_stiffness(DD, DD).fill(-s * s);
 
     trial_stress(6) = s * s * (trial_stress(6) - trial_strain(6));
 

--- a/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.cpp
+++ b/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.cpp
@@ -83,11 +83,12 @@ int NonlocalIsotropicElastic3D::update_trial_status(const vec& t_strain) {
     trial_stiffness(UD, UD) *= 1. - trial_strain(6);
 
     const auto [s, ds] = compute_scale(trial_stress(6));
+    const auto s2 = s * s;
 
-    trial_stiffness(DD, UD) *= s * s + 2. * s * ds * (trial_stress(6) - trial_strain(6));
-    trial_stiffness(DD, DD).fill(-s * s);
+    trial_stiffness(DD, UD) *= s2 + 2. * s * ds * (trial_stress(6) - trial_strain(6));
+    trial_stiffness(DD, DD).fill(-s2);
 
-    trial_stress(6) = s * s * (trial_stress(6) - trial_strain(6));
+    trial_stress(6) = s2 * (trial_stress(6) - trial_strain(6));
 
     return SUANPAN_SUCCESS;
 }

--- a/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.cpp
+++ b/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.cpp
@@ -87,6 +87,8 @@ int NonlocalIsotropicElastic3D::update_trial_status(const vec& t_strain) {
     trial_stiffness(d_dof, u_dof) *= s * s + 2. * s * ds * (trial_stress(6) - trial_strain(6));
     trial_stiffness(d_dof, d_dof).fill(-s * s);
 
+    trial_stress(6) = s * s * (trial_stress(6) - trial_strain(6));
+
     return SUANPAN_SUCCESS;
 }
 

--- a/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.h
+++ b/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.h
@@ -55,7 +55,7 @@ public:
     };
 
 private:
-    static const uvec u_dof, d_dof;
+    static const uvec UD, DD;
 
     const EnergyType energy_type;
 

--- a/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.h
+++ b/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.h
@@ -84,10 +84,6 @@ public:
 
     int update_trial_status(const vec&) override;
 
-    int clear_status() override;
-    int commit_status() override;
-    int reset_status() override;
-
     void print() override;
 };
 

--- a/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.h
+++ b/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.h
@@ -62,7 +62,6 @@ private:
     [[nodiscard]] std::pair<double, double> compute_scale(const double k) const {
         const auto exp_term = std::exp(diffusion_rate * k);
         const auto s = exp_term / reference_length;
-
         return {s, diffusion_rate * s};
     }
 

--- a/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.h
+++ b/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.h
@@ -59,7 +59,12 @@ private:
 
     const EnergyType energy_type;
 
-    [[nodiscard]] std::pair<double, double> compute_scale(double) const { return {1. / reference_length, 0.}; }
+    [[nodiscard]] std::pair<double, double> compute_scale(const double k) const {
+        const auto exp_term = std::exp(diffusion_rate * k);
+        const auto s = exp_term / reference_length;
+
+        return {s, diffusion_rate * s};
+    }
 
 public:
     NonlocalIsotropicElastic3D(

--- a/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.h
+++ b/Material/Material3D/Nonlocal/NonlocalIsotropicElastic3D.h
@@ -42,6 +42,8 @@ struct DataNonlocalIsotropicElastic3D {
     const double poissons_ratio;
     const double maximum_energy;
     const double evolution_rate;
+    const double reference_length;
+    const double diffusion_rate;
 };
 
 class NonlocalIsotropicElastic3D final : protected DataNonlocalIsotropicElastic3D, public NonlocalMaterial3D {
@@ -57,12 +59,16 @@ private:
 
     const EnergyType energy_type;
 
+    [[nodiscard]] std::pair<double, double> compute_scale(double) const { return {1. / reference_length, 0.}; }
+
 public:
     NonlocalIsotropicElastic3D(
         unsigned,   // tag
         double,     // elastic modulus
         double,     // poissons ratio
         double,     // maximum energy
+        double,     // evolution rate
+        double,     // reference length
         double,     // evolution rate
         EnergyType, // energy type
         double = 0. // density

--- a/Material/MaterialParser.cpp
+++ b/Material/MaterialParser.cpp
@@ -2200,8 +2200,8 @@ namespace {
             return;
         }
 
-        double elastic_modulus, poissons_ratio, maximum_energy, evolution_rate;
-        if(!get_input(command, elastic_modulus, poissons_ratio, maximum_energy, evolution_rate)) {
+        double elastic_modulus, poissons_ratio, maximum_energy, evolution_rate, reference_length, diffusion_rate;
+        if(!get_input(command, elastic_modulus, poissons_ratio, maximum_energy, evolution_rate, reference_length, diffusion_rate)) {
             suanpan_error("A valid parameter is required.\n");
             return;
         }
@@ -2214,7 +2214,7 @@ namespace {
             return;
         }
 
-        return_obj = std::make_unique<NonlocalIsotropicElastic3D>(tag, elastic_modulus, poissons_ratio, maximum_energy, evolution_rate, NonlocalIsotropicElastic3D::EnergyType::DEV_TENSILE, density);
+        return_obj = std::make_unique<NonlocalIsotropicElastic3D>(tag, elastic_modulus, poissons_ratio, maximum_energy, evolution_rate, reference_length, diffusion_rate, NonlocalIsotropicElastic3D::EnergyType::DEV_TENSILE, density);
     }
 
     void new_elasticos(unique_ptr<Material>& return_obj, std::istringstream& command) {

--- a/Material/MaterialParser.cpp
+++ b/Material/MaterialParser.cpp
@@ -808,8 +808,8 @@ namespace {
             return;
         }
 
-        double elastic_modulus, poissons_ratio, yield_stress, plastic_strain_threshold, evolution_rate;
-        if(!get_input(command, elastic_modulus, poissons_ratio, yield_stress, plastic_strain_threshold, evolution_rate)) {
+        double elastic_modulus, poissons_ratio, yield_stress, plastic_strain_threshold, evolution_rate, reference_length, diffusion_rate;
+        if(!get_input(command, elastic_modulus, poissons_ratio, yield_stress, plastic_strain_threshold, evolution_rate, reference_length, diffusion_rate)) {
             suanpan_error("A valid parameter is required.\n");
             return;
         }
@@ -820,7 +820,7 @@ namespace {
             return;
         }
 
-        return_obj = std::make_unique<NonlocalBilinearJ2>(tag, elastic_modulus, poissons_ratio, yield_stress, plastic_strain_threshold, evolution_rate, hardening_ratio, beta, density);
+        return_obj = std::make_unique<NonlocalBilinearJ2>(tag, elastic_modulus, poissons_ratio, yield_stress, plastic_strain_threshold, evolution_rate, reference_length, diffusion_rate, hardening_ratio, beta, density);
     }
 
     void new_bilinearmises1d(unique_ptr<Material>& return_obj, std::istringstream& command) {


### PR DESCRIPTION
Enhance nonlocal material classes by removing the characteristic length parameter and introducing reference length and diffusion rate parameters. Update constructors, status management methods, and trial stress calculations accordingly. Adjust material and element definitions to reflect these changes.